### PR TITLE
Add installation of signed EFI to grub.efi

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+grub2 (2.12-1deepin6) unstable; urgency=medium
+
+  * x64: Also install signed efi to grub.efi.
+
+ -- Tianyu Chen <sweetyfish@deepin.org>  Fri, 29 Mar 2024 11:56:19 +0800
+
 grub2 (2.12-1deepin5) unstable; urgency=medium
 
   * Disable verification of font files.

--- a/debian/patches/deepin-Also-install-x86_64-efi-to-grub-efi.patch
+++ b/debian/patches/deepin-Also-install-x86_64-efi-to-grub-efi.patch
@@ -1,0 +1,24 @@
+Description: Also install signed efi to grub.efi
+Author: Tianyu Chen <sweetyfish@deepin.org>
+Origin: vendor
+# Bug-Deepin: <URL to the vendor bug report if any, optional>
+Forwarded: not-needed
+Last-Update: 2024-03-29
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- a/util/grub-install.c
++++ b/util/grub-install.c
+@@ -2181,6 +2181,13 @@
+ 		chained_dst = grub_util_path_concat (2, efidir, chained_base);
+ 		grub_install_copy_file (efi_signed, chained_dst, 1);
+ 
++		// Also install to grub.efi
++		if (strcmp (efi_suffix, "x64") == 0) {
++			char *chained_dst_grub_efi = grub_util_path_concat (2, efidir, "grub.efi");
++			grub_install_copy_file (efi_signed, chained_dst_grub_efi, 1);
++			free(chained_dst_grub_efi);
++		}
++
+ 		/* Not critical, so not an error if they are not present (as it
+ 		   won't be for older releases); but if we have them, make
+ 		   sure they are installed.  */

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -96,3 +96,4 @@ uniontech0033-enable-grub-background-on-huawei-2
 revert-fwsetup-is-supported.patch
 # Revert "kern/efi/sb: Enforce verification of font files"
 kern-efi-sb-Enforce-verification-of-font-files.patch
+deepin-Also-install-x86_64-efi-to-grub-efi.patch


### PR DESCRIPTION
This commit adds functionality to also install the signed EFI to
grub.efi in addition to the existing installation process.

This enhancement ensures that the signed EFI is properly installed to
both grubx64.efi and grub.efi.
