### PR TITLE
fix(grub-mkrescue.c): use upper-case EFI paths

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+grub2 (2.12-1deepin7) unstable; urgency=medium
+
+  * grub-mkrescue: use upper-case paths for EFI images.
+    * This is needed to generate bootable ISOs on Loongson firmware.
+    * /efi/boot/bootloongarch64.efi => /EFI/BOOT/BOOTLOONGARCH64.EFI.
+    * This shouldn't cause problems with other architectures, AFAIK.
+  * See: https://lists.gnu.org/archive/html/grub-devel/2024-06/msg00101.html
+
+ -- Mingcong Bai <baimingcong@uniontech.com>  Thu, 13 Jun 2024 19:36:24 +0800
+
 grub2 (2.12-1deepin6) unstable; urgency=medium
 
   * x64: Also install signed efi to grub.efi.

--- a/debian/patches/deepin/0001-util-grub-mkrescue-use-capitalised-paths-for-removab.patch
+++ b/debian/patches/deepin/0001-util-grub-mkrescue-use-capitalised-paths-for-removab.patch
@@ -1,0 +1,97 @@
+From 8a52d2d391b662681f7c92286ab9e45906119b5d Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Tue, 11 Jun 2024 22:40:24 +0800
+Subject: [PATCH] util/grub-mkrescue: use capitalised paths for removable EFI
+ images
+
+Per UEFI Specification, section 3.4.1.1:
+
+... If FilePathList[0] points to a device that supports the
+EFI_SIMPLE_FILE_SYSTEM_PROTOCOL, then the system firmware will attempt to boot
+from a removable media FilePathList[0] by adding a default file name in the
+form \EFI\BOOT\BOOT{machine type short-name}.EFI.
+
+While FAT < 32 filesystems are not case sensitive (which grub-mkrescue creates
+as a FAT12 image via mformat with a size of 2.88MiB), it seems that
+some of Loongson's LoongArch-based firmware (namely those found on their
+latest XA61200 boards) seems to treat this file system as case-sensitive. In
+this case, at least the XA61200 board seems incapable of identifying
+/efi/boot/bootloongarch64.efi as a valid removable EFI image.
+
+In any case, according to the UEFI Specification, all paths and image
+filenames should be capitalised (with the exception of BOOTx64.EFI, according
+to section 3.5.1.1, for some reason) to stay compliant. The Loongson case is
+only one example of users running into buggy firmware and unbootable GRUB
+ISO images.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ util/grub-mkrescue.c | 20 ++++++++++----------
+ 1 file changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/util/grub-mkrescue.c b/util/grub-mkrescue.c
+index 27696e034..cfb749967 100644
+--- a/util/grub-mkrescue.c
++++ b/util/grub-mkrescue.c
+@@ -769,8 +769,8 @@ main (int argc, char *argv[])
+       || source_dirs[GRUB_INSTALL_PLATFORM_RISCV64_EFI])
+     {
+       FILE *f;
+-      char *efidir_efi = grub_util_path_concat (2, iso9660_dir, "efi");
+-      char *efidir_efi_boot = grub_util_path_concat (3, iso9660_dir, "efi", "boot");
++      char *efidir_efi = grub_util_path_concat (2, iso9660_dir, "EFI");
++      char *efidir_efi_boot = grub_util_path_concat (3, iso9660_dir, "EFI", "BOOT");
+       char *imgname, *img32, *img64, *img_mac = NULL;
+       char *efiimgfat, *iso_uuid_file, *diskdir, *diskdir_uuid;
+       grub_install_mkdir_p (efidir_efi_boot);
+@@ -792,39 +792,39 @@ main (int argc, char *argv[])
+       free (diskdir_uuid);
+       free (diskdir);
+ 
+-      imgname = grub_util_path_concat (2, efidir_efi_boot, "bootia64.efi");
++      imgname = grub_util_path_concat (2, efidir_efi_boot, "BOOTIA64.EFI");
+       make_image_fwdisk_abs (GRUB_INSTALL_PLATFORM_IA64_EFI, "ia64-efi", imgname);
+       free (imgname);
+ 
+       grub_install_push_module ("part_apple");
+-      img64 = grub_util_path_concat (2, efidir_efi_boot, "bootx64.efi");
++      img64 = grub_util_path_concat (2, efidir_efi_boot, "BOOTx64.EFI");
+       make_image_abs (GRUB_INSTALL_PLATFORM_X86_64_EFI, "x86_64-efi", img64);
+       grub_install_pop_module ();
+ 
+       grub_install_push_module ("part_apple");
+-      img32 = grub_util_path_concat (2, efidir_efi_boot, "bootia32.efi");
++      img32 = grub_util_path_concat (2, efidir_efi_boot, "BOOTIA32.EFI");
+       make_image_abs (GRUB_INSTALL_PLATFORM_I386_EFI, "i386-efi", img32);
+       grub_install_pop_module ();
+ 
+-      imgname = grub_util_path_concat (2, efidir_efi_boot, "bootarm.efi");
++      imgname = grub_util_path_concat (2, efidir_efi_boot, "BOOTARM.EFI");
+       make_image_abs (GRUB_INSTALL_PLATFORM_ARM_EFI, "arm-efi", imgname);
+       free (imgname);
+ 
+-      imgname = grub_util_path_concat (2, efidir_efi_boot, "bootaa64.efi");
++      imgname = grub_util_path_concat (2, efidir_efi_boot, "BOOTAA64.EFI");
+       make_image_abs (GRUB_INSTALL_PLATFORM_ARM64_EFI, "arm64-efi", imgname);
+       free (imgname);
+ 
+-      imgname = grub_util_path_concat (2, efidir_efi_boot, "bootloongarch64.efi");
++      imgname = grub_util_path_concat (2, efidir_efi_boot, "BOOTLOONGARCH64.EFI");
+       make_image_fwdisk_abs (GRUB_INSTALL_PLATFORM_LOONGARCH64_EFI,
+ 			     "loongarch64-efi",
+ 			     imgname);
+       free (imgname);
+ 
+-      imgname = grub_util_path_concat (2, efidir_efi_boot, "bootriscv32.efi");
++      imgname = grub_util_path_concat (2, efidir_efi_boot, "BOOTRISCV32.EFI");
+       make_image_abs (GRUB_INSTALL_PLATFORM_RISCV32_EFI, "riscv32-efi", imgname);
+       free (imgname);
+ 
+-      imgname = grub_util_path_concat (2, efidir_efi_boot, "bootriscv64.efi");
++      imgname = grub_util_path_concat (2, efidir_efi_boot, "BOOTRISCV64.EFI");
+       make_image_abs (GRUB_INSTALL_PLATFORM_RISCV64_EFI, "riscv64-efi", imgname);
+       free (imgname);
+ 
+-- 
+2.43.4
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -97,3 +97,8 @@ revert-fwsetup-is-supported.patch
 # Revert "kern/efi/sb: Enforce verification of font files"
 kern-efi-sb-Enforce-verification-of-font-files.patch
 deepin-Also-install-x86_64-efi-to-grub-efi.patch
+# EFI path fix, useful for buggy firmware (such as Loongson) that do not treat
+# FAT ESPs as case-insensitive. Currently pre-upstream:
+#
+# https://lists.gnu.org/archive/html/grub-devel/2024-06/msg00101.html
+deepin/0001-util-grub-mkrescue-use-capitalised-paths-for-removab.patch


### PR DESCRIPTION
- This is needed to generate bootable ISOs on Loongson firmware. 
    - /efi/boot/bootloongarch64.efi => /EFI/BOOT/BOOTLOONGARCH64.EFI.
- This shouldn't cause problems with other architectures, AFAIK.

Ref: https://lists.gnu.org/archive/html/grub-devel/2024-06/msg00101.html