### PR TITLE
feat: set GRUB_DEVICE by env when root is overlayfs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+grub2 (2.12-1deepin9) unstable; urgency=medium
+
+  * set GRUB_DEVICE by env when root is overlayfs
+
+ -- xiamengliang <xiamengliang@uniontech.com>  Thu, 01 Aug 2024 16:36:49 +0800
+
 grub2 (2.12-1deepin8) unstable; urgency=medium
 
   * (loong64) Introduce a patch for old-world firmware compatibility.

--- a/debian/patches/deepin/0002-probe-grub-device-for-overlay-as-root.patch
+++ b/debian/patches/deepin/0002-probe-grub-device-for-overlay-as-root.patch
@@ -1,0 +1,23 @@
+--- a/util/grub-mkconfig.in
++++ b/util/grub-mkconfig.in
+@@ -131,8 +131,19 @@
+     exit 1
+ fi
+ 
++get_root_device() {
++	ROOT_UUID="$(awk '{for(i=1;i<=NF;i++) if ($i ~ /^root=UUID=/) {print $i; break} }' /proc/cmdline)"
++	ROOT_UUID=${ROOT_UUID#root=UUID=}
++	realpath /dev/disk/by-uuid/$ROOT_UUID
++}
++
+ # Device containing our userland.  Typically used for root= parameter.
+-GRUB_DEVICE="`${grub_probe} --target=device /`"
++if [ -z "$GRUB_DEVICE" ]; then
++	  GRUB_DEVICE="$(${grub_probe} --target=device / 2>/dev/null|| true)"
++fi
++if [ -z "$GRUB_DEVICE" ]; then
++	  GRUB_DEVICE=$(get_root_device)
++fi
+ GRUB_DEVICE_UUID="`${grub_probe} --device ${GRUB_DEVICE} --target=fs_uuid 2> /dev/null`" || true
+ GRUB_DEVICE_PARTUUID="`${grub_probe} --device ${GRUB_DEVICE} --target=partuuid 2> /dev/null`" || true
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -105,3 +105,4 @@ deepin/0001-util-grub-mkrescue-use-capitalised-paths-for-removab.patch
 # loong64 old-world firmware compatibility
 0001-loongarch64-able-to-start-on-legacy-firmware.patch
 0001-grub-install-loongarch64-efi-also-install-BOOTLOONGA.patch
+deepin/0002-probe-grub-device-for-overlay-as-root.patch


### PR DESCRIPTION
set GRUB_DEVICE by env when root is overlayfs

Log: set GRUB_DEVICE by env when root is overlayfs