### PR TITLE
fix: support translate for shell

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+grub2 (2.12-1deepin18) unstable; urgency=medium
+
+  * add translate for shell.
+
+ -- xinpeng.wang <wangxinpeng@uniontech.com>  Thu, 17 Apr 2025 19:03:04 +0800
+
 grub2 (2.12-1deepin17) unstable; urgency=medium
 
   * Introduce more patches from AOSC-Tracking/grub to fix boot memory

--- a/debian/patches/0018-add-custom-keywords-translation.patch
+++ b/debian/patches/0018-add-custom-keywords-translation.patch
@@ -30,8 +30,8 @@ Change-Id: Id3ed8f3f2c423c94f14e8a9d24310f3e7d80e7b1
 +#~ msgstr "系统还原"
 +
 +#: util/grub.d/30_uefi-firmware.in:42
-+#~ msgid "System Setup"
-+#~ msgstr "系统设置"
++msgid "System Setup"
++msgstr "系统设置"
 +
  #: util/grub.d/10_illumos.in:40
  #, c-format

--- a/debian/patches/revert-fwsetup-is-supported.patch
+++ b/debian/patches/revert-fwsetup-is-supported.patch
@@ -21,7 +21,7 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
 -gettext_printf "Adding boot menu entry for UEFI Firmware Settings ...\n" >&2
 +if [ -e "$OS_INDICATIONS" ] && \
 +   [ "$(( $(printf 0x%x \'"$(cat $OS_INDICATIONS | cut -b5)"\') & 1 ))" = 1 ]; then
-+  LABEL="UEFI Firmware Settings"
++  LABEL="System Setup"
  
 -gettext_printf "System Setup" >/dev/null 2>&1
 -gettext_printf "UnionTech OS Restore" >/dev/null 2>&1
@@ -41,7 +41,7 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
 -			fwsetup
 -		}
 -	fi
-+menuentry '$LABEL' \$menuentry_id_option 'uefi-firmware' {
++menuentry '$(gettext_printf "System Setup")' \$menuentry_id_option 'uefi-firmware' {
 +        fwsetup
 +}
  fi

--- a/debian/rules
+++ b/debian/rules
@@ -190,9 +190,11 @@ override_dh_autoreconf:
 	set -e; for extra in 915resolution ntldr-img; do \
 		cp -a debian/grub-extras/$$extra debian/grub-extras-enabled/; \
 	done
+	cp po/Makefile.in.in po/Mafile.ininbak
 	env -u DH_OPTIONS GRUB_CONTRIB=$(CURDIR)/debian/grub-extras-enabled \
 		PYTHON=python3 \
 		dh_autoreconf -- ./autogen.sh
+	mv po/Mafile.ininbak po/Makefile.in.in
 	cp /usr/share/lzo/minilzo/*.c /usr/share/lzo/minilzo/*.h grub-core/lib/minilzo/
 
 debian/stamps/configure-grub-common: debian/stamps/configure-grub-$(COMMON_PLATFORM)


### PR DESCRIPTION
Bugs: 313307

支持对shell的翻译。
参考bug 313307备注，上游的问题；现在不能对shell脚本进行翻译，仿照v20进行修改。

## Summary by Sourcery

Bug Fixes:
- Resolve an upstream issue preventing translation of shell scripts, implementing a fix similar to version 20