### PR TITLE
Fix: grub-pc install fail in noninteractive && all arch types support…

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+grub2 (2.12-7deepin2) unstable; urgency=medium
+
+  * fix grub-pc install fail in noninteractive mode.
+  * support translate in all arch types
+
+ -- xinpeng.wang <wangxinpeng@uniontech.com>  Fri, 25 Apr 2025 17:17:09 +0800
+
 grub2 (2.12-7deepin1) unstable; urgency=medium
 
   * Apply patches from deepin grub2 2.06.

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -153,7 +153,7 @@ cve-2025-jan/fs-xfs-Handle-root-inode-read-failure-in-grub_xfs_mount.patch
 0016-loongson_xfs_install_grub_add_fonts.patch
 0018-add-custom-keywords-translation.patch
 0019-fix-grub.patch
-0025-fix-when-installing-the-package-execute-update-grub.patch
+#0025-fix-when-installing-the-package-execute-update-grub.patch
 0026-fix-Del-lockdown-reg.patch
 0027-fix-can-not-boot-bug.patch
 0029-fix-arm64-terminal-output-to-console.patch

--- a/debian/postinst.in
+++ b/debian/postinst.in
@@ -528,6 +528,13 @@ case "$1" in
         elif test -e /boot/grub/core.img || \
              test -e /boot/grub/@FIRST_CPU_PLATFORM@/core.img || \
              test "$UPGRADE_FROM_GRUB_LEGACY" || test "$wubi_device"; then
+          # avoid grub-pc/install_devices to be NULL when non-interact install was performed
+          db_get grub-pc/install_devices
+          if [ "x$RET" == "x" ];then
+              install_partition=`df /boot/grub|egrep "^/dev"|awk '{print $1}'`
+              install_devices="/dev/"`lsblk -s $install_partition |grep disk|awk '{print $1}'|sed -e 's/[^a-zA-Z0-9]//g'|sort|uniq`
+              db_set grub-pc/install_devices $install_devices
+          fi
           question=grub-pc/install_devices
           priority=high
           device_map="$(grub-mkdevicemap -m - | grep -v '^(fd[0-9]\+)' || true)"


### PR DESCRIPTION
… translate

Bug: 314213 313819

## Summary by Sourcery

Bug Fixes:
- Resolve installation failures for grub-pc in non-interactive mode across multiple architecture types