### PR TITLE
feat: update efi files for Loongarch

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+grub2 (2.12-7deepin4) unstable; urgency=medium
+
+  * update efi files for loongarch
+
+ -- bluesky <chenchongbiao@deepin.org>  Mon, 12 May 2025 13:40:59 +0800
+
 grub2 (2.12-7deepin3) unstable; urgency=medium
 
   * fix compile error.

--- a/debian/postinst.in
+++ b/debian/postinst.in
@@ -333,6 +333,36 @@ run_grub_install()
     fi
 }
 
+record_loongarch_efi_files()
+{
+  local target_file target_hash file_name source_hash
+
+  source_hash=$(sha256sum "$source_file" | awk '{print $1}')
+  for target_file in "$boot_efi_dir"/*; do
+    target_hash=$(sha256sum "$target_file" | awk '{print $1}')
+    if [ "$target_hash" == "$source_hash" ]; then
+        file_name=$(basename "$target_file")
+        loongarch_efi_files+=("$file_name")
+    fi
+  done
+}
+
+update_efi_files_for_loongarch() {
+  local file target_file target_hash source_hash
+
+  source_hash=$(sha256sum "$source_file" | awk '{print $1}')
+  for file in "${loongarch_efi_files[@]}"; do
+    target_file="$boot_efi_dir/$file"
+    if [ -f "$target_file" ]; then
+      target_hash=$(sha256sum "$target_file" | awk '{print $1}')
+
+      if [ "$source_hash" != "$target_hash" ]; then
+        cp "$source_file" "$target_file"
+      fi
+    fi
+  done
+}
+
 case "$1" in
   configure)
     . /usr/share/debconf/confmodule
@@ -729,6 +759,13 @@ case "$1" in
       grub-efi-ia32|grub-efi-amd64|grub-efi-ia64|grub-efi-arm|grub-efi-arm64|grub-efi-riscv64|grub-efi-loong64)
         bootloader_id="$(config_item GRUB_DISTRIBUTOR | tr A-Z a-z | \
                          cut -d' ' -f1)"
+        if [ @PACKAGE@ = grub-efi-loong64 ]; then
+          distro_efi_dir="/boot/efi/EFI/$bootloader_id"
+          boot_efi_dir="/boot/efi/EFI/BOOT"
+          source_file="$distro_efi_dir/grubloongarch64.efi"
+          declare -a loongarch_efi_files=()
+          record_loongarch_efi_files
+        fi
         case $bootloader_id in
           kubuntu) bootloader_id=ubuntu ;;
           devuan) bootloader_id=debian ;;
@@ -760,6 +797,10 @@ case "$1" in
 
         if type update-secureboot-policy >/dev/null 2>&1; then
           update-secureboot-policy || true
+        fi
+
+        if [ @PACKAGE@ = grub-efi-loong64 ]; then
+          update_efi_files_for_loongarch
         fi
       ;;
 


### PR DESCRIPTION
由于龙芯固件问题,只能识别 /boot/efi/EFI/BOOT 下的efi文件,另一方面在 grub-efi-loong64 更新后,只会更新 /boot/efi/EFI/deepin 发行版目录下的 EFI 文件,导致系统更新完无法正常引导.(可以进入 bios 从 uefi shell 使用旧的 EFI 启动系统),这里新增 record_loongarch_efi_files 函数先记录与发行版目录下与 BOOT 目录下相同的 EFI  文件,避免后续更新覆盖双系统的 EFI 文件,(当然双系统安装后系统启动的 EFI 文件,取决于最后一次安装的 EFI 文件,可以使用 uefi shell 手动选择指定的 EFI 引导,另外最后一次安装系统的 GRUB 会将前一个安装的系统的内核也扫描),函数 update_efi_files_for_loongarch,在更新完引导后,比较 deepin 目录与 BOOT 目录下 grubloongarch64.efi 是否相同.另外设备的固件只识别 BOOTLOONGARCH64.EFI 和 BOOTLOONGARCH.EFI 需要拷贝一份.

Log: fix update efi for Loongarch

## Summary by Sourcery

Improve EFI file handling for Loongarch systems to ensure proper boot functionality after bootloader updates.

New Features:
- Add function to update EFI files for Loongarch architecture after bootloader updates.

Bug Fixes:
- Ensure EFI files are correctly copied to /boot/efi/EFI/BOOT for Loongarch systems to fix boot issues after updates.