### PR TITLE
Fix: mips not support zh_CN

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+grub2 (2.12-7deepin5) unstable; urgency=medium
+
+  * mips not support zh_CN.
+
+ -- xinpeng.wang <wangxinpeng@uniontech.com>  Tue, 10 Jun 2025 19:13:48 +0800
+
 grub2 (2.12-7deepin4) unstable; urgency=medium
 
   * update efi files for loongarch

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -203,3 +203,4 @@ mips/0012-kern-efi-mm-mips64-allocate-more-memory-at-initializ.patch
 mips/0013-fix-include-add-a-small-header-to-dummy-boot.h-and-t.patch
 mips/0014-loader-mips64-linux-properly-prepare-memory-for-init.patch
 mips/0015-fix-util-grub-mkimagexx-unconditionaly-use-64-bit-ad.patch
+uniontech-mips-set-lang-c.patch

--- a/debian/patches/uniontech-mips-set-lang-c.patch
+++ b/debian/patches/uniontech-mips-set-lang-c.patch
@@ -1,0 +1,15 @@
+Index: grub2/util/grub-mkconfig.in
+===================================================================
+--- grub2.orig/util/grub-mkconfig.in	2025-06-10 17:10:47.000000000 +0800
++++ grub2/util/grub-mkconfig.in	2025-06-10 17:17:41.297169413 +0800
+@@ -208,6 +208,10 @@
+     esac
+ done
+ 
++if [ "$(uname -m)" = "mips64" ]; then
++    export LANG=C;
++fi
++
+ GRUB_ACTUAL_DEFAULT="$GRUB_DEFAULT"
+ 
+ if [ "x${GRUB_ACTUAL_DEFAULT}" = "xsaved" ] ; then GRUB_ACTUAL_DEFAULT="`"${grub_editenv}" - list | sed -n '/^saved_entry=/ s,^saved_entry=,,p'`" ; fi


### PR DESCRIPTION
Bugs: 312175

## Summary by Sourcery

Fix locale support on MIPS by adding a Debian patch that forces the LANG to C when zh_CN is unavailable.

Bug Fixes:
- Force the LANG to C on MIPS architectures to workaround lack of zh_CN locale support.

Build:
- Add uniontech-mips-set-lang-c.patch to the Debian packaging series and update changelog.