### PR TITLE
fix: Use time register in grub_efi_get_time_ms()

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+grub2 (2.12-7deepin6) unstable; urgency=medium
+
+  * kern/riscv/efi/init: Use time register in grub_efi_get_time_ms()
+    (backport from c5ae124e11f28f637cbd38cb4d6c1b9817baa135)
+
+ -- Chang Yang <yangchang@deepin.org>  Thu, 18 Sep 2025 17:08:48 +0800
+
 grub2 (2.12-7deepin5) unstable; urgency=medium
 
   * mips not support zh_CN.

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -204,3 +204,6 @@ mips/0013-fix-include-add-a-small-header-to-dummy-boot.h-and-t.patch
 mips/0014-loader-mips64-linux-properly-prepare-memory-for-init.patch
 mips/0015-fix-util-grub-mkimagexx-unconditionaly-use-64-bit-ad.patch
 uniontech-mips-set-lang-c.patch
+
+# backport: fix riscv64 rdcycle
+use-time-register-in-grub_efi_get_time_ms.patch

--- a/debian/patches/use-time-register-in-grub_efi_get_time_ms.patch
+++ b/debian/patches/use-time-register-in-grub_efi_get_time_ms.patch
@@ -1,0 +1,46 @@
+From f9f2e0ec8bfc7117d13520219cc99459de6e99d5 Mon Sep 17 00:00:00 2001
+From: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>
+Date: Mon, 12 Aug 2024 16:13:18 +0200
+Subject: [PATCH] UPSTREAM: kern/riscv/efi/init: Use time register in
+ grub_efi_get_time_ms()
+
+The cycle register is not guaranteed to count at constant frequency.
+If it is counting at all depends on the state the performance monitoring
+unit. Use the time register to measure time.
+
+Signed-off-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+(cherry picked from commit c5ae124e11f28f637cbd38cb4d6c1b9817baa135)
+Signed-off-by: Han Gao <rabenda.cn@gmail.com>
+---
+ grub-core/kern/riscv/efi/init.c | 15 +++++++--------
+ 1 file changed, 7 insertions(+), 8 deletions(-)
+
+diff --git a/grub-core/kern/riscv/efi/init.c b/grub-core/kern/riscv/efi/init.c
+index 38795fe67..0d7de4f54 100644
+--- a/grub-core/kern/riscv/efi/init.c
++++ b/grub-core/kern/riscv/efi/init.c
+@@ -33,16 +33,15 @@ grub_efi_get_time_ms (void)
+   grub_uint64_t tmr;
+ 
+ #if __riscv_xlen == 64
+-  asm volatile ("rdcycle %0" : "=r" (tmr));
++  asm volatile ("rdtime %0" : "=r"(tmr));
+ #else
+   grub_uint32_t lo, hi, tmp;
+-  asm volatile (
+-    "1:\n"
+-    "rdcycleh %0\n"
+-    "rdcycle %1\n"
+-    "rdcycleh %2\n"
+-    "bne %0, %2, 1b"
+-    : "=&r" (hi), "=&r" (lo), "=&r" (tmp));
++  asm volatile ("1:\n"
++                "rdtimeh %0\n"
++                "rdtime %1\n"
++                "rdtimeh %2\n"
++                "bne %0, %2, 1b"
++                : "=&r" (hi), "=&r" (lo), "=&r" (tmp));
+   tmr = ((grub_uint64_t)hi << 32) | lo;
+ #endif
+ 


### PR DESCRIPTION
See https://github.com/AOSC-Tracking/grub/pull/3.

## Summary by Sourcery

Add a Debian packaging patch to make grub_efi_get_time_ms use the UEFI time register for accurate time measurement and update the changelog and patch series accordingly.

Bug Fixes:
- Make grub_efi_get_time_ms use the UEFI time register instead of performance counters to fix timing inaccuracies.

Build:
- Add use-time-register-in-grub_efi_get_time_ms.patch and update debian/changelog and debian/patches/series.