### PR TITLE
Apply cve-2025-nov patch series

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+grub2 (2.12-7deepin7) unstable; urgency=medium
+
+  * Apply cve-2025-nov patch series.
+  * Bump SBAT 'grub' entry to 6.
+  * Set DPKG_VENDOR to Deepin, SB_EFI_VENDOR to deepin.
+
+ -- Tianyu Chen <sweetyfish@deepin.org>  Thu, 27 Nov 2025 16:15:11 +0800
+
 grub2 (2.12-7deepin6) unstable; urgency=medium
 
   * kern/riscv/efi/init: Use time register in grub_efi_get_time_ms()

--- a/debian/patches/cve-2025-nov/commands-test-Fix-error-in-recursion-depth-calculati.patch
+++ b/debian/patches/cve-2025-nov/commands-test-Fix-error-in-recursion-depth-calculati.patch
@@ -1,0 +1,35 @@
+From: Thomas Frauendorfer | Miray Software <tf@miray.de>
+Date: Fri, 9 May 2025 13:51:08 +0200
+Subject: commands/test: Fix error in recursion depth calculation
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 8bit
+
+The commit c68b7d236 (commands/test: Stack overflow due to unlimited
+recursion depth) added recursion depth tests to the test command. But in
+the error case it decrements the pointer to the depth value instead of
+the value itself. Fix it.
+
+Fixes: c68b7d236 (commands/test: Stack overflow due to unlimited recursion depth)
+
+Signed-off-by: Thomas Frauendorfer | Miray Software <tf@miray.de>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+(cherry picked from commit cc9d621dd06bfa12eac511b37b4ceda5bd2f8246)
+Signed-off-by: Fabian Grünbichler <f.gruenbichler@proxmox.com>
+---
+ grub-core/commands/test.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/grub-core/commands/test.c b/grub-core/commands/test.c
+index b585c3d..ee47ab2 100644
+--- a/grub-core/commands/test.c
++++ b/grub-core/commands/test.c
+@@ -403,7 +403,7 @@ test_parse (char **args, int *argn, int argc, int *depth)
+ 	  if (++(*depth) > MAX_TEST_RECURSION_DEPTH)
+ 	    {
+ 	      grub_error (GRUB_ERR_OUT_OF_RANGE, N_("max recursion depth exceeded"));
+-	      depth--;
++	      (*depth)--;
+ 	      return ctx.or || ctx.and;
+ 	    }
+ 

--- a/debian/patches/cve-2025-nov/commands-usbtest-Ensure-string-length-is-sufficient-.patch
+++ b/debian/patches/cve-2025-nov/commands-usbtest-Ensure-string-length-is-sufficient-.patch
@@ -1,0 +1,33 @@
+From: Jamie <volticks@gmail.com>
+Date: Mon, 14 Jul 2025 10:07:47 +0100
+Subject: commands/usbtest: Ensure string length is sufficient in usb string
+ processing
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 8bit
+
+If descstrp->length is less than 2 this will result in underflow in
+"descstrp->length / 2 - 1" math. Let's fix the check to make sure the
+value is sufficient.
+
+Signed-off-by: Jamie <volticks@gmail.com>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+(cherry picked from commit 7debdce1e98907e65223a4b4c53a41345ac45e53)
+Signed-off-by: Fabian Grünbichler <f.gruenbichler@proxmox.com>
+---
+ grub-core/commands/usbtest.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/grub-core/commands/usbtest.c b/grub-core/commands/usbtest.c
+index 8ef187a..3184ac9 100644
+--- a/grub-core/commands/usbtest.c
++++ b/grub-core/commands/usbtest.c
+@@ -90,7 +90,7 @@ grub_usb_get_string (grub_usb_device_t dev, grub_uint8_t index, int langid,
+ 			      0x06, (3 << 8) | index,
+ 			      langid, descstr.length, (char *) descstrp);
+ 
+-  if (descstrp->length == 0)
++  if (descstrp->length < 2)
+     {
+       grub_free (descstrp);
+       *string = grub_strdup ("");

--- a/debian/patches/cve-2025-nov/commands-usbtest-Use-correct-string-length-field.patch
+++ b/debian/patches/cve-2025-nov/commands-usbtest-Use-correct-string-length-field.patch
@@ -1,0 +1,35 @@
+From: Jamie <volticks@gmail.com>
+Date: Mon, 14 Jul 2025 09:52:59 +0100
+Subject: commands/usbtest: Use correct string length field
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 8bit
+
+An incorrect length field is used for buffer allocation. This leads to
+grub_utf16_to_utf8() receiving an incorrect/different length and possibly
+causing OOB write. This makes sure to use the correct length.
+
+Fixes: CVE-2025-61661
+
+Reported-by: Jamie <volticks@gmail.com>
+Signed-off-by: Jamie <volticks@gmail.com>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+(cherry picked from commit 549a9cc372fd0b96a4ccdfad0e12140476cc62a3)
+Signed-off-by: Fabian Grünbichler <f.gruenbichler@proxmox.com>
+---
+ grub-core/commands/usbtest.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/grub-core/commands/usbtest.c b/grub-core/commands/usbtest.c
+index 2c6d93f..8ef187a 100644
+--- a/grub-core/commands/usbtest.c
++++ b/grub-core/commands/usbtest.c
+@@ -99,7 +99,7 @@ grub_usb_get_string (grub_usb_device_t dev, grub_uint8_t index, int langid,
+       return GRUB_USB_ERR_NONE;
+     }
+ 
+-  *string = grub_malloc (descstr.length * 2 + 1);
++  *string = grub_malloc (descstrp->length * 2 + 1);
+   if (! *string)
+     {
+       grub_free (descstrp);

--- a/debian/patches/cve-2025-nov/gettext-gettext-Unregister-gettext-command-on-module.patch
+++ b/debian/patches/cve-2025-nov/gettext-gettext-Unregister-gettext-command-on-module.patch
@@ -1,0 +1,66 @@
+From: Alec Brown <alec.r.brown@oracle.com>
+Date: Thu, 21 Aug 2025 21:14:06 +0000
+Subject: gettext/gettext: Unregister gettext command on module unload
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 8bit
+
+When the gettext module is loaded, the gettext command is registered but
+isn't unregistered when the module is unloaded. We need to add a call to
+grub_unregister_command() when unloading the module.
+
+Fixes: CVE-2025-61662
+
+Reported-by: Alec Brown <alec.r.brown@oracle.com>
+Signed-off-by: Alec Brown <alec.r.brown@oracle.com>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+(cherry picked from commit 8ed78fd9f0852ab218cc1f991c38e5a229e43807)
+Signed-off-by: Fabian Grünbichler <f.gruenbichler@proxmox.com>
+---
+ grub-core/gettext/gettext.c | 19 ++++++++++++-------
+ 1 file changed, 12 insertions(+), 7 deletions(-)
+
+diff --git a/grub-core/gettext/gettext.c b/grub-core/gettext/gettext.c
+index f6a9f5a..cf4c75e 100644
+--- a/grub-core/gettext/gettext.c
++++ b/grub-core/gettext/gettext.c
+@@ -507,6 +507,8 @@ grub_cmd_translate (grub_command_t cmd __attribute__ ((unused)),
+   return 0;
+ }
+ 
++static grub_command_t cmd;
++
+ GRUB_MOD_INIT (gettext)
+ {
+   const char *lang;
+@@ -526,13 +528,14 @@ GRUB_MOD_INIT (gettext)
+   grub_register_variable_hook ("locale_dir", NULL, read_main);
+   grub_register_variable_hook ("secondary_locale_dir", NULL, read_secondary);
+ 
+-  grub_register_command_p1 ("gettext", grub_cmd_translate,
+-			    N_("STRING"),
+-			    /* TRANSLATORS: It refers to passing the string through gettext.
+-			       So it's "translate" in the same meaning as in what you're
+-			       doing now.
+-			     */
+-			    N_("Translates the string with the current settings."));
++  cmd = grub_register_command_p1 ("gettext", grub_cmd_translate,
++				  N_("STRING"),
++				  /*
++				   * TRANSLATORS: It refers to passing the string through gettext.
++				   * So it's "translate" in the same meaning as in what you're
++				   * doing now.
++				   */
++				  N_("Translates the string with the current settings."));
+ 
+   /* Reload .mo file information if lang changes.  */
+   grub_register_variable_hook ("lang", NULL, grub_gettext_env_write_lang);
+@@ -549,6 +552,8 @@ GRUB_MOD_FINI (gettext)
+   grub_register_variable_hook ("secondary_locale_dir", NULL, NULL);
+   grub_register_variable_hook ("lang", NULL, NULL);
+ 
++  grub_unregister_command (cmd);
++
+   grub_gettext_delete_list (&main_context);
+   grub_gettext_delete_list (&secondary_context);
+ 

--- a/debian/patches/cve-2025-nov/kern-file-Call-grub_dl_unref-after-fs-fs_close.patch
+++ b/debian/patches/cve-2025-nov/kern-file-Call-grub_dl_unref-after-fs-fs_close.patch
@@ -1,0 +1,46 @@
+From: Thomas Frauendorfer | Miray Software <tf@miray.de>
+Date: Wed, 7 May 2025 16:15:22 +0200
+Subject: kern/file: Call grub_dl_unref() after fs->fs_close()
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 8bit
+
+With commit 16f196874 (kern/file: Implement filesystem reference
+counting) files hold a reference to their file systems.
+
+When closing a file in grub_file_close() we should not expect
+file->fs to stay valid after calling grub_dl_unref() on file->fs->mod.
+So, grub_dl_unref() should be called after file->fs->fs_close().
+
+Fixes: CVE-2025-54771
+Fixes: 16f196874 (kern/file: Implement filesystem reference counting)
+
+Reported-by: Thomas Frauendorfer | Miray Software <tf@miray.de>
+Signed-off-by: Thomas Frauendorfer | Miray Software <tf@miray.de>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+(cherry picked from commit c4fb4cbc941981894a00ba8e75d634a41967a27f)
+Signed-off-by: Fabian Grünbichler <f.gruenbichler@proxmox.com>
+---
+ grub-core/kern/file.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/grub-core/kern/file.c b/grub-core/kern/file.c
+index 6e7efe8..eb52fd2 100644
+--- a/grub-core/kern/file.c
++++ b/grub-core/kern/file.c
+@@ -201,12 +201,12 @@ grub_file_read (grub_file_t file, void *buf, grub_size_t len)
+ grub_err_t
+ grub_file_close (grub_file_t file)
+ {
+-  if (file->fs->mod)
+-    grub_dl_unref (file->fs->mod);
+-
+   if (file->fs->fs_close)
+     (file->fs->fs_close) (file);
+ 
++  if (file->fs->mod)
++    grub_dl_unref (file->fs->mod);
++
+   if (file->device)
+     grub_device_close (file->device);
+   grub_free (file->name);

--- a/debian/patches/cve-2025-nov/net-net-Unregister-net_set_vlan-command-on-unload.patch
+++ b/debian/patches/cve-2025-nov/net-net-Unregister-net_set_vlan-command-on-unload.patch
@@ -1,0 +1,36 @@
+From: Thomas Frauendorfer | Miray Software <tf@miray.de>
+Date: Fri, 9 May 2025 14:20:47 +0200
+Subject: net/net: Unregister net_set_vlan command on unload
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 8bit
+
+The commit 954c48b9c (net/net: Add net_set_vlan command) added command
+net_set_vlan to the net module. Unfortunately the commit only added the
+grub_register_command() call on module load but missed the
+grub_unregister_command() on unload. Let's fix this.
+
+Fixes: CVE-2025-54770
+Fixes: 954c48b9c (net/net: Add net_set_vlan command)
+
+Reported-by: Thomas Frauendorfer | Miray Software <tf@miray.de>
+Signed-off-by: Thomas Frauendorfer | Miray Software <tf@miray.de>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+(cherry picked from commit 10e58a14db20e17d1b6a39abe38df01fef98e29d)
+Signed-off-by: Fabian Grünbichler <f.gruenbichler@proxmox.com>
+---
+ grub-core/net/net.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/grub-core/net/net.c b/grub-core/net/net.c
+index 7ec4823..864c125 100644
+--- a/grub-core/net/net.c
++++ b/grub-core/net/net.c
+@@ -2289,6 +2289,7 @@ GRUB_MOD_FINI(net)
+   grub_unregister_command (cmd_deladdr);
+   grub_unregister_command (cmd_addroute);
+   grub_unregister_command (cmd_delroute);
++  grub_unregister_command (cmd_setvlan);
+   grub_unregister_command (cmd_lsroutes);
+   grub_unregister_command (cmd_lscards);
+   grub_unregister_command (cmd_lsaddr);

--- a/debian/patches/cve-2025-nov/normal-main-Unregister-commands-on-module-unload.patch
+++ b/debian/patches/cve-2025-nov/normal-main-Unregister-commands-on-module-unload.patch
@@ -1,0 +1,59 @@
+From: Alec Brown <alec.r.brown@oracle.com>
+Date: Thu, 21 Aug 2025 21:14:07 +0000
+Subject: normal/main: Unregister commands on module unload
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 8bit
+
+When the normal module is loaded, the normal and normal_exit commands
+are registered but aren't unregistered when the module is unloaded. We
+need to add calls to grub_unregister_command() when unloading the module
+for these commands.
+
+Fixes: CVE-2025-61663
+Fixes: CVE-2025-61664
+
+Reported-by: Alec Brown <alec.r.brown@oracle.com>
+Signed-off-by: Alec Brown <alec.r.brown@oracle.com>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+(cherry picked from commit 05d3698b8b03eccc49e53491bbd75dba15f40917)
+Signed-off-by: Fabian Grünbichler <f.gruenbichler@proxmox.com>
+---
+ grub-core/normal/main.c | 12 +++++++-----
+ 1 file changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/grub-core/normal/main.c b/grub-core/normal/main.c
+index 527b249..ed45ee3 100644
+--- a/grub-core/normal/main.c
++++ b/grub-core/normal/main.c
+@@ -582,7 +582,7 @@ grub_mini_cmd_clear (struct grub_command *cmd __attribute__ ((unused)),
+   return 0;
+ }
+ 
+-static grub_command_t cmd_clear;
++static grub_command_t cmd_clear, cmd_normal, cmd_normal_exit;
+ 
+ static void (*grub_xputs_saved) (const char *str);
+ static const char *features[] = {
+@@ -624,10 +624,10 @@ GRUB_MOD_INIT(normal)
+   grub_env_export ("pager");
+ 
+   /* Register a command "normal" for the rescue mode.  */
+-  grub_register_command ("normal", grub_cmd_normal,
+-			 0, N_("Enter normal mode."));
+-  grub_register_command ("normal_exit", grub_cmd_normal_exit,
+-			 0, N_("Exit from normal mode."));
++  cmd_normal = grub_register_command ("normal", grub_cmd_normal,
++				      0, N_("Enter normal mode."));
++  cmd_normal_exit = grub_register_command ("normal_exit", grub_cmd_normal_exit,
++					   0, N_("Exit from normal mode."));
+ 
+   /* Reload terminal colors when these variables are written to.  */
+   grub_register_variable_hook ("color_normal", NULL, grub_env_write_color_normal);
+@@ -669,4 +669,6 @@ GRUB_MOD_FINI(normal)
+   grub_register_variable_hook ("color_highlight", NULL, NULL);
+   grub_fs_autoload_hook = 0;
+   grub_unregister_command (cmd_clear);
++  grub_unregister_command (cmd_normal);
++  grub_unregister_command (cmd_normal_exit);
+ }

--- a/debian/patches/cve-2025-nov/tests-lib-functional_test-Unregister-commands-on-mod.patch
+++ b/debian/patches/cve-2025-nov/tests-lib-functional_test-Unregister-commands-on-mod.patch
@@ -1,0 +1,47 @@
+From: Alec Brown <alec.r.brown@oracle.com>
+Date: Thu, 21 Aug 2025 21:14:08 +0000
+Subject: tests/lib/functional_test: Unregister commands on module unload
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 8bit
+
+When the functional_test module is loaded, both the functional_test and
+all_functional_test commands are registered but only the all_functional_test
+command is being unregistered since it was the last to set the cmd variable
+that gets unregistered when the module is unloaded. To unregister both
+commands, we need to create an additional grub_extcmd_t variable.
+
+Signed-off-by: Alec Brown <alec.r.brown@oracle.com>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+(cherry picked from commit 9df1e693e70c5a274b6d60dc76efe2694b89c2fc)
+Signed-off-by: Fabian Grünbichler <f.gruenbichler@proxmox.com>
+---
+ grub-core/tests/lib/functional_test.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/grub-core/tests/lib/functional_test.c b/grub-core/tests/lib/functional_test.c
+index 96781fb..b0f6845 100644
+--- a/grub-core/tests/lib/functional_test.c
++++ b/grub-core/tests/lib/functional_test.c
+@@ -89,17 +89,18 @@ grub_functional_all_tests (grub_extcmd_context_t ctxt __attribute__ ((unused)),
+   return GRUB_ERR_NONE;
+ }
+ 
+-static grub_extcmd_t cmd;
++static grub_extcmd_t cmd, cmd_all;
+ 
+ GRUB_MOD_INIT (functional_test)
+ {
+   cmd = grub_register_extcmd ("functional_test", grub_functional_test, 0, 0,
+ 			      "Run all loaded functional tests.", 0);
+-  cmd = grub_register_extcmd ("all_functional_test", grub_functional_all_tests, 0, 0,
+-			      "Run all functional tests.", 0);
++  cmd_all = grub_register_extcmd ("all_functional_test", grub_functional_all_tests, 0, 0,
++				  "Run all functional tests.", 0);
+ }
+ 
+ GRUB_MOD_FINI (functional_test)
+ {
+   grub_unregister_extcmd (cmd);
++  grub_unregister_extcmd (cmd_all);
+ }

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -144,6 +144,14 @@ cve-2025-jan/fs-ext2-Rework-out-of-bounds-read-for-inline-and-external.patch
 cve-2025-jan/fs-xfs-Fix-grub_xfs_iterate_dir-return-value-in-case-of-f.patch
 cve-2025-jan/fs-xfs-Propagate-incorrect-inode-error-from-grub_xfs_read.patch
 cve-2025-jan/fs-xfs-Handle-root-inode-read-failure-in-grub_xfs_mount.patch
+cve-2025-nov/commands-test-Fix-error-in-recursion-depth-calculati.patch
+cve-2025-nov/kern-file-Call-grub_dl_unref-after-fs-fs_close.patch
+cve-2025-nov/net-net-Unregister-net_set_vlan-command-on-unload.patch
+cve-2025-nov/gettext-gettext-Unregister-gettext-command-on-module.patch
+cve-2025-nov/normal-main-Unregister-commands-on-module-unload.patch
+cve-2025-nov/tests-lib-functional_test-Unregister-commands-on-mod.patch
+cve-2025-nov/commands-usbtest-Use-correct-string-length-field.patch
+cve-2025-nov/commands-usbtest-Ensure-string-length-is-sufficient-.patch
 0001_grub2_2.02_beta3-4_deepin-gfxmode-mod.patch
 0003-fix_grub_efidisk_open_logic.patch
 0006-fix-loongson-laptop-blurry-screen.patch

--- a/debian/rules
+++ b/debian/rules
@@ -164,6 +164,10 @@ endif
 DPKG_VENDOR ?= $(shell dpkg-vendor --query vendor)
 SB_EFI_VENDOR ?= $(shell dpkg-vendor --query vendor | tr '[:upper:]' '[:lower:]')
 
+DPKG_VENDOR = Deepin
+SB_EFI_VENDOR = deepin
+
+
 %:
 	dh $@ --with=bash_completion
 

--- a/debian/sbat.debian.csv.in
+++ b/debian/sbat.debian.csv.in
@@ -1,5 +1,5 @@
 sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
-grub,5,Free Software Foundation,grub,@UPSTREAM_VERSION@,https://www.gnu.org/software/grub/
+grub,6,Free Software Foundation,grub,@UPSTREAM_VERSION@,https://www.gnu.org/software/grub/
 grub.debian,5,Debian,grub2,@DEB_VERSION@,https://tracker.debian.org/pkg/grub2
 grub.debian13,1,Debian,grub2,@DEB_VERSION@,https://tracker.debian.org/pkg/grub2
 grub.peimage,2,Canonical,grub2,@DEB_VERSION@,https://salsa.debian.org/grub-team/grub/-/blob/master/debian/patches/secure-boot/efi-use-peimage-shim.patch

--- a/debian/sbat.deepin.csv.in
+++ b/debian/sbat.deepin.csv.in
@@ -1,5 +1,5 @@
 sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
-grub,4,Free Software Foundation,grub,@UPSTREAM_VERSION@,https://www.gnu.org/software/grub/
-grub.debian,4,Debian,grub2,2.12-7,https://tracker.debian.org/pkg/grub2
+grub,6,Free Software Foundation,grub,@UPSTREAM_VERSION@,https://www.gnu.org/software/grub/
+grub.debian,5,Debian,grub2,2.12-7,https://tracker.debian.org/pkg/grub2
 grub.deepin,1,Deepin,grub2,@DEB_VERSION@,https://github.com/deepin-community/grub2
 grub.peimage,2,Canonical,grub2,@DEB_VERSION@,https://salsa.debian.org/grub-team/grub/-/blob/master/debian/patches/secure-boot/efi-use-peimage-shim.patch

--- a/debian/sbat.uos.csv.in
+++ b/debian/sbat.uos.csv.in
@@ -1,5 +1,5 @@
 sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
-grub,4,Free Software Foundation,grub,@UPSTREAM_VERSION@,https://www.gnu.org/software/grub/
-grub.debian,4,Debian,grub2,2.12-7,https://tracker.debian.org/pkg/grub2
+grub,6,Free Software Foundation,grub,@UPSTREAM_VERSION@,https://www.gnu.org/software/grub/
+grub.debian,5,Debian,grub2,2.12-7,https://tracker.debian.org/pkg/grub2
 grub.uos,1,Uos,grub2,@DEB_VERSION@,https://github.com/deepin-community/grub2
 grub.peimage,2,Canonical,grub2,@DEB_VERSION@,https://salsa.debian.org/grub-team/grub/-/blob/master/debian/patches/secure-boot/efi-use-peimage-shim.patch


### PR DESCRIPTION
- Bump SBAT 'grub' entry to 6
- Set DPKG_VENDOR to Deepin, SB_EFI_VENDOR to deepin

## Summary by Sourcery

Apply November 2025 CVE patch set to grub and update Debian packaging metadata accordingly.

Bug Fixes:
- Backport upstream fixes for recursion depth calculation, USB test string handling, and proper module/command unregistration in grub to address security and stability issues.

Enhancements:
- Update SBAT CSV entries and bump the grub SBAT generation to align with the new patched build.
- Set Debian packaging vendor variables (DPKG_VENDOR, SB_EFI_VENDOR) for Deepin-based builds to ensure correct vendor identification.

Build:
- Register the new cve-2025-nov patch series in the Debian patch list and changelog so it is applied during package builds.