### PR TITLE
feat：grub-install support secureboot detect for loongarch64

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+grub2 (2.12-7deepin8) unstable; urgency=medium
+
+  * grub-install support secureboot detect for loongarch64
+
+ -- zhouzilong <zhouzilong@uniontech.com>  Wed, 07 Jan 2026 16:43:23 +0800
+
 grub2 (2.12-7deepin7) unstable; urgency=medium
 
   * Apply cve-2025-nov patch series.

--- a/debian/patches/deepin/0006-grub-install-support-secureboot-detect-for-loongarch.patch
+++ b/debian/patches/deepin/0006-grub-install-support-secureboot-detect-for-loongarch.patch
@@ -1,0 +1,24 @@
+From f055b17ace49b9bfcda18eedfdf18a36b9d54ec0 Mon Sep 17 00:00:00 2001
+From: zhouzilong <zhouzilong@uniontech.com>
+Date: Wed, 7 Jan 2026 16:14:18 +0800
+Subject: [PATCH] grub-install support secureboot detect for loongarch64
+
+---
+ util/grub-install.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/util/grub-install.c b/util/grub-install.c
+index 3fb1bb8..a0eebae 100644
+--- a/util/grub-install.c
++++ b/util/grub-install.c
+@@ -1557,6 +1557,7 @@ main (int argc, char *argv[])
+     case GRUB_INSTALL_PLATFORM_ARM_EFI:
+     case GRUB_INSTALL_PLATFORM_ARM64_EFI:
+     case GRUB_INSTALL_PLATFORM_IA64_EFI:
++    case GRUB_INSTALL_PLATFORM_LOONGARCH64_EFI:
+       {
+ 	char *dir = xasprintf ("%s-signed", grub_install_source_directory);
+ 	char *signed_image;
+-- 
+2.20.1
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -215,3 +215,5 @@ uniontech-mips-set-lang-c.patch
 
 # backport: fix riscv64 rdcycle
 use-time-register-in-grub_efi_get_time_ms.patch
+
+deepin/0006-grub-install-support-secureboot-detect-for-loongarch.patch


### PR DESCRIPTION
## Summary by Sourcery

Add Debian packaging changes to support secure boot detection for loongarch64 in grub-install via a new downstream patch.

New Features:
- Introduce secure boot detection support for loongarch64 in grub-install through a new Debian patch.

Enhancements:
- Update Debian changelog and patch series to register the new loongarch64 secure boot support patch.