### PR TITLE
fix: suppress stderr for grub-probe in uses_abstraction function

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+grub2 (2.12-7deepin9) unstable; urgency=medium
+
+  * Silence stderr in uses_abstraction function within grub-mkconfig_lib.
+  * This prevents confusing memory leak warnings and error messages when 
+    grub-probe encounters unsupported encryption algorithms like SM4.
+
+ -- xinpeng.wang <wangxinpeng@uniontech.com>  Thu, 05 Mar 2026 20:56:00 +0800
+
 grub2 (2.12-7deepin8) unstable; urgency=medium
 
   * grub-install support secureboot detect for loongarch64

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -217,3 +217,4 @@ uniontech-mips-set-lang-c.patch
 use-time-register-in-grub_efi_get_time_ms.patch
 
 deepin/0006-grub-install-support-secureboot-detect-for-loongarch.patch
+uniontech-mkconfig_lib-suppress-stderr-for-grub-probe-in-uses_abstraction.patch

--- a/debian/patches/uniontech-mkconfig_lib-suppress-stderr-for-grub-probe-in-uses_abstraction.patch
+++ b/debian/patches/uniontech-mkconfig_lib-suppress-stderr-for-grub-probe-in-uses_abstraction.patch
@@ -1,0 +1,13 @@
+Index: grub2/util/grub-mkconfig_lib.in
+===================================================================
+--- grub2.orig/util/grub-mkconfig_lib.in
++++ grub2/util/grub-mkconfig_lib.in
+@@ -347,7 +347,7 @@ uses_abstraction () {
+   IFS='
+ '
+ 
+-  abstraction="`"${grub_probe}" --device ${device} --target=abstraction`"
++  abstraction="`"${grub_probe}" --device ${device} --target=abstraction 2>/dev/null`"
+   for module in ${abstraction}; do
+     if test "x${module}" = "x$2"; then
+       IFS="$old_ifs"


### PR DESCRIPTION
The `grub-probe` utility may output error messages or internal memory leak warnings to stderr when it encounters unsupported encryption ciphers (e.g., SM4/SM3 in some GRUB versions). When called via `uses_abstraction` during `update-grub`, these messages clutter the terminal and confuse users.

By redirecting stderr to /dev/null within the backticks:
- Console output remains clean during configuration generation.
- The function continues to work correctly: if `grub-probe` fails, the abstraction variable remains empty and the function returns 1.
- Prevents build/update failures in environments with strict error logging.

fix: 在 uses_abstraction 函数中抑制 grub-probe 的标准错误输出

当 `grub-probe` 遇到不支持的加密算法（如某些 GRUB 版本中的 SM4）时，
会向标准错误流（stderr）输出错误信息或内部内存泄漏警告。在
`update-grub` 过程中通过 `uses_abstraction` 调用时，这些信息会干扰 终端显示并误导用户。

通过在反引号内部将 stderr 重定向到 /dev/null：
- 保持配置生成过程中的控制台输出整洁。
- 函数逻辑保持正常：若 `grub-probe` 失败，变量为空，函数返回 1（非真）。
- 防止在具有严格错误日志监控的环境中导致更新失败。
 pms: 346569

## Summary by Sourcery

Suppress grub-probe stderr output in the uses_abstraction helper to avoid noisy errors during update-grub while preserving existing behavior.

Bug Fixes:
- Prevent spurious grub-probe error and leak messages from appearing on stderr during update-grub when encountering unsupported encryption ciphers.

Enhancements:
- Add a Debian patch and register it in the patches series and changelog to apply the grub-probe stderr suppression in mkconfig_lib.