### PR TITLE
feat(i18n): add Chinese translation for System Rescue menu entry

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+grub2 (2.12-7deepin10) unstable; urgency=medium
+
+  * feat(i18n): Add Chinese translation for "System Rescue" menu entry.
+
+ -- xinpeng.wang <wangxinpeng@uniontech.com>  Mon, 16 Mar 2026 17:50:56 +0800
+
 grub2 (2.12-7deepin9) unstable; urgency=medium
 
   * Silence stderr in uses_abstraction function within grub-mkconfig_lib.

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -218,3 +218,4 @@ use-time-register-in-grub_efi_get_time_ms.patch
 
 deepin/0006-grub-install-support-secureboot-detect-for-loongarch.patch
 uniontech-mkconfig_lib-suppress-stderr-for-grub-probe-in-uses_abstraction.patch
+uniontech-update-zh-cn-translate.patch

--- a/debian/patches/uniontech-update-zh-cn-translate.patch
+++ b/debian/patches/uniontech-update-zh-cn-translate.patch
@@ -1,0 +1,36 @@
+Index: grub2/po/zh_CN.po
+===================================================================
+--- grub2.orig/po/zh_CN.po
++++ grub2/po/zh_CN.po
+@@ -7440,7 +7440,7 @@ msgid "Advanced options for %s"
+ msgstr "%s 的高级选项"
+ 
+ 
+-#: util/grub.d/15_linux_bar.in:40
++#: util/grub.d/30_uefi-firmware.in:40
+ #~ msgid "UnionTech OS Restore"
+ #~ msgstr "系统还原"
+ 
+@@ -7448,6 +7448,10 @@ msgstr "%s 的高级选项"
+ msgid "System Setup"
+ msgstr "系统设置"
+ 
++#: util/grub.d/30_uefi-firmware.in:49
++msgid "System Rescue"
++msgstr "系统修复"
++
+ #: util/grub.d/10_illumos.in:40
+ #, c-format
+ msgid "Loading kernel of Illumos ..."
+Index: grub2/util/grub.d/30_uefi-firmware.in
+===================================================================
+--- grub2.orig/util/grub.d/30_uefi-firmware.in
++++ grub2/util/grub.d/30_uefi-firmware.in
+@@ -45,6 +45,7 @@ if [ -e "$OS_INDICATIONS" ] && \
+ 
+   gettext_printf "System Setup" >/dev/null 2>&1
+   gettext_printf "UnionTech OS Restore" >/dev/null 2>&1
++  gettext_printf "System Rescue" >/dev/null 2>&1
+ 
+   if [ "x$hw_support" != x"true" ];then
+     cat << EOF


### PR DESCRIPTION
Added new Chinese translation for "System Rescue" menu entry in UEFI firmware boot options Updated zh_CN.po translation file with the new string Modified 30_uefi-firmware.in to include the new translatable string Added the translation patch to debian patches series for packaging

Log: Added Chinese translation for System Rescue menu option

Influence:
1. Verify System Rescue menu entry appears correctly in Chinese locale
2. Test UEFI firmware menu display with Chinese language settings
3. Confirm translation patch applies correctly during packaging
4. Validate GRUB menu generation with the new translation

feat(i18n): 为系统修复菜单项添加中文翻译

在UEFI固件启动选项中新增"System Rescue"菜单项的中文翻译
更新zh_CN.po翻译文件，添加新的翻译字符串
修改30_uefi-firmware.in文件以包含新的可翻译字符串
将翻译补丁添加到debian补丁系列中用于打包

Log: 新增系统修复菜单选项的中文翻译

Influence:
1. 验证中文语言环境下系统修复菜单项正确显示
2. 测试中文语言设置的UEFI固件菜单显示
3. 确认翻译补丁在打包过程中正确应用
4. 验证包含新翻译的GRUB菜单生成 pms: 353127

## Summary by Sourcery

Add a packaging patch to update Chinese translations for the UEFI System Rescue menu entry and record the change in Debian packaging metadata.

New Features:
- Introduce a Chinese translation for the UEFI System Rescue menu entry via a new translation patch.

Enhancements:
- Update Debian changelog and patch series to include the new Chinese translation patch for zh_CN.