### PR TITLE
fix(util): skip directory entries with .mo/.gmo suffix in copy_locales()

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+grub2 (2.12-7deepin11) unstable; urgency=medium
+
+  * fix(util): Skip directory entries with .mo/.gmo suffix in copy_locales().
+    On some systems, there may be directories under /usr/share/locale/ with
+    names ending in .gmo (e.g., fi.gmo/), which causes grub-install to fail
+    when it tries to copy them as regular files.
+
+ -- lichenggang <lichenggang@uniontech.com>  Tue, 17 Mar 2026 09:30:00 +0800
+
 grub2 (2.12-7deepin10) unstable; urgency=medium
 
   * feat(i18n): Add Chinese translation for "System Rescue" menu entry.

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -10,6 +10,7 @@ gettext-quiet.patch
 install-efi-fallback.patch
 mkconfig-ubuntu-recovery.patch
 install-locale-langpack.patch
+skip-directory-check.patch
 mkconfig-nonexistent-loopback.patch
 default-grub-d.patch
 blacklist-1440x900x32.patch

--- a/debian/patches/skip-directory-check.patch
+++ b/debian/patches/skip-directory-check.patch
@@ -1,0 +1,27 @@
+Description: fix(util): skip directory entries with .mo/.gmo suffix in copy_locales()
+ On some systems, there may be directories under /usr/share/locale/ with
+ names ending in .gmo (e.g., fi.gmo/), which causes grub-install to fail
+ when it tries to copy them as regular files.
+ Fix: In copy_locales(), check if a .mo or .gmo entry is a directory
+ before attempting to copy it. If it is a directory, skip it.
+ This patch must be applied after install-locale-langpack.patch.
+Author: lichenggang <lichenggang@uniontech.com>
+Forwarded: backported-from-upstream
+Last-Update: 2026-03-17
+
+Index: grub2/util/grub-install-common.c
+===================================================================
+--- grub2.orig/util/grub-install-common.c
++++ grub2/util/grub-install-common.c
+@@ -822,6 +822,11 @@ copy_locales (const char *dstd, int langpack)
+ 		  || grub_strcmp (ext, ".gmo") == 0))
+ 	{
+ 	  srcf = grub_util_path_concat (2, dir, de->d_name);
++	  if (grub_util_is_directory (srcf))
++	    {
++	      free (srcf);
++	      continue;
++	    }
+ 	  dstf = grub_util_path_concat (2, dstd, de->d_name);
+ 	  ext = grub_strrchr (dstf, '.');
+ 	  grub_strcpy (ext, ".mo");


### PR DESCRIPTION
On some systems, there may be directories under /usr/share/locale/ with names ending in .gmo (e.g., fi.gmo/), which causes grub-install to fail when it tries to copy them as regular files.

## Description

This patch adds a directory check in copy_locales() to skip directories with .mo or .gmo suffix, preventing copy failures that occur on systems with locale directories named like `fi.gmo/`.

## Changes

- Added directory check for .mo/.gmo entries in copy_locales()
- Skip directory entries when copying locale files  
- Updated debian packaging files (changelog, series, and patch)
- Patch applied after install-locale-langpack.patch due to code structure changes

## Testing

✅ Verified with `dpkg-source --before-build` - all patches apply successfully without errors

## Upstream

Backported from: https://gitlab.freedesktop.org/gnu-grub/grub/-/merge_requests/6

## Reference

Closes: https://gitlab.freedesktop.org/gnu-grub/grub/-/merge_requests/6

## Summary by Sourcery

Skip problematic locale directories with .mo/.gmo suffix when copying locales and update Debian packaging to include the backported patch.

Bug Fixes:
- Prevent grub-install failures by skipping locale directory entries with .mo/.gmo suffix instead of treating them as regular files during copy_locales().

Build:
- Add and wire up a Debian patch to skip .mo/.gmo locale directories, updating changelog and patch series accordingly.