### PR TITLE
feat: add SW64 architecture  package support

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+grub2 (2.12-7deepin14) unstable; urgency=medium
+
+  * fix(sw64): fix EFI call compatibility and PE machine detection
+  * sw64: Add declaration for grub_sw64_dl_get_tramp_got_size
+
+ -- lichenggang <lichenggang@deepin.org>  Mon, 18 May 2026 09:24:50 +0800
+
 grub2 (2.12-7deepin13) unstable; urgency=medium
 
   * feat: Add SW64 arch debian package support.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+grub2 (2.12-7deepin13) unstable; urgency=medium
+
+  * feat: Add SW64 arch debian package support.
+  * feat: Add sw64 to Build-Depends architecture lists and package
+    architectures.
+
+ -- lichenggang <lichenggang@uniontech.com>  Fri, 15 May 2026 14:45:11 +0800
+
 grub2 (2.12-7deepin12) unstable; urgency=medium
 
   * feat: Add SW64 arch support.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+grub2 (2.12-7deepin12) unstable; urgency=medium
+
+  * feat: Add SW64 arch support.
+
+ -- sunway_fw <sunway_fw@wxiat.com>  Wed, 6 May 2026 09:30:00 +0800
+
 grub2 (2.12-7deepin11) unstable; urgency=medium
 
   * fix(util): Skip directory entries with .mo/.gmo suffix in copy_locales().

--- a/debian/control
+++ b/debian/control
@@ -29,13 +29,13 @@ Build-Depends: debhelper-compat (= 13),
  liblzo2-dev,
  lzop,
  dosfstools [any-i386 any-amd64 any-arm64],
- squashfs-tools [any-i386 any-arm any-amd64 any-arm64 any-ia64 any-loong64 any-riscv64],
+ squashfs-tools [any-i386 any-arm any-amd64 any-arm64 any-ia64 any-loong64 any-riscv64 sw64],
  wamerican,
  libparted-dev [any-powerpc any-ppc64 any-ppc64el],
  pkgconf,
  bash-completion,
- libefiboot-dev [i386 amd64 ia64 x32 armel armhf arm64 riscv64 loong64],
- libefivar-dev [i386 amd64 ia64 x32 armel armhf arm64 riscv64 loong64],
+ libefiboot-dev [i386 amd64 ia64 x32 armel armhf arm64 riscv64 loong64 sw64],
+ libefivar-dev [i386 amd64 ia64 x32 armel armhf arm64 riscv64 loong64 sw64],
 Build-Conflicts: autoconf2.13, libzfs-dev, libnvpair-dev
 Standards-Version: 3.9.6
 Homepage: https://www.gnu.org/software/grub/
@@ -63,9 +63,9 @@ Description: GRand Unified Bootloader, version 2 (dummy package)
  This is a dummy transitional package that depends on grub-coreboot.
 
 Package: grub-efi
-Architecture: any-i386 any-amd64 any-arm64 any-ia64 any-arm any-riscv64 any-loong64 any-mips64el
+Architecture: any-i386 any-amd64 any-arm64 any-ia64 any-arm any-riscv64 any-loong64 any-mips64el sw64
 Pre-Depends: ${misc:Pre-Depends}
-Depends: ${misc:Depends}, grub-efi-ia32 (= ${binary:Version}) [any-i386], grub-efi-amd64 (= ${binary:Version}) [any-amd64], grub-efi-arm64 (= ${binary:Version}) [any-arm64], grub-efi-ia64 (= ${binary:Version}) [any-ia64], grub-efi-arm (= ${binary:Version}) [any-arm], grub-efi-riscv64 (= ${binary:Version}) [any-riscv64], grub-efi-loong64 (= ${binary:Version}) [any-loong64], grub-efi-misp64el (= ${binary:Version}) [any-mips64el]
+Depends: ${misc:Depends}, grub-efi-ia32 (= ${binary:Version}) [any-i386], grub-efi-amd64 (= ${binary:Version}) [any-amd64], grub-efi-arm64 (= ${binary:Version}) [any-arm64], grub-efi-ia64 (= ${binary:Version}) [any-ia64], grub-efi-arm (= ${binary:Version}) [any-arm], grub-efi-riscv64 (= ${binary:Version}) [any-riscv64], grub-efi-loong64 (= ${binary:Version}) [any-loong64], grub-efi-misp64el (= ${binary:Version}) [any-mips64el], grub-efi-sw64 (= ${binary:Version}) [sw64]
 Multi-Arch: foreign
 Description: GRand Unified Bootloader, version 2 (dummy package)
  This is a dummy package that depends on the grub-efi-$ARCH package most likely
@@ -77,7 +77,7 @@ Built-Using: ${Built-Using}
 Depends: ${shlibs:Depends}, ${misc:Depends}, gettext-base, ${lsb-base-depends}
 Replaces: grub-pc (<< 2.00-4), grub-ieee1275 (<< 2.00-4), grub-efi (<< 1.99-1), grub-coreboot (<< 2.00-4), grub-linuxbios (<< 1.96+20080831-1), grub-efi-ia32 (<< 2.00-4), grub-efi-amd64 (<< 2.00-4), grub-efi-ia64 (<< 2.00-4), grub-yeeloong (<< 2.00-4), init-select
 Recommends: os-prober (>= 1.33)
-Suggests: multiboot-doc, grub-emu [any-i386 any-amd64 any-powerpc], mtools [any-i386 any-amd64 any-ia64 any-arm any-arm64 riscv64 any-loong64 mips64el], xorriso (>= 0.5.6.pl00), desktop-base (>= 4.0.6), console-setup
+Suggests: multiboot-doc, grub-emu [any-i386 any-amd64 any-powerpc], mtools [any-i386 any-amd64 any-ia64 any-arm any-arm64 riscv64 any-loong64 mips64el sw64], xorriso (>= 0.5.6.pl00), desktop-base (>= 4.0.6), console-setup
 Conflicts: init-select
 # mdadm: See bugs #435983 and #455746
 Breaks: mdadm (<< 2.6.7-2), lupin-support (<< 0.55), friendly-recovery (<< 0.2.13), apport (<< 2.1.1), grub-efi-amd64-signed (<< 1+2.12~rc1), grub-efi-arm64-signed (<< 1+2.12~rc1), grub-efi-ia32-signed (<< 1+2.12~rc1)
@@ -94,7 +94,7 @@ Package: grub2-common
 # Not Architecture: any because this package contains some things which are
 # only built when there is a real platform (e.g. grub-install), and the rest
 # of the package is not very useful in a utilities-only build.
-Architecture: any-i386 any-amd64 any-powerpc any-ppc64 any-ppc64el any-sparc any-sparc64 any-mipsel any-ia64 any-arm any-arm64 any-riscv64 any-loong64 any-mips64el
+Architecture: any-i386 any-amd64 any-powerpc any-ppc64 any-ppc64el any-sparc any-sparc64 any-mipsel any-ia64 any-arm any-arm64 any-riscv64 any-loong64 any-mips64el sw64
 Depends: grub-common (= ${binary:Version}), dpkg (>= 1.15.4), ${shlibs:Depends}, ${misc:Depends}
 Replaces: grub, grub-legacy, ${legacy-doc-br}, grub-common (<< 1.99-1), grub-pc (<< 2.02+dfsg1-7), grub-coreboot (<< 2.02+dfsg1-7), grub-efi-ia32 (<< 2.02+dfsg1-7), grub-efi-amd64 (<< 2.02+dfsg1-7), grub-efi-ia64 (<< 2.02+dfsg1-7), grub-efi-arm (<< 2.02+dfsg1-7), grub-efi-arm64 (<< 2.02+dfsg1-7), grub-ieee1275 (<< 2.02+dfsg1-7), grub-uboot (<< 2.02+dfsg1-7), grub-xen (<< 2.02+dfsg1-7), grub-yeeloong (<< 2.02+dfsg1-7), grub-cloud-amd64 (<< 0.0.4)
 Breaks: grub (<< 0.97-54), grub-legacy (<< 0.97-83~), ${legacy-doc-br}, shim (<< 0.9+1474479173.6c180c6-0ubuntu1~), grub-pc (<< 2.02+dfsg1-7), grub-coreboot (<< 2.02+dfsg1-7), grub-efi-ia32 (<< 2.02+dfsg1-7), grub-efi-amd64 (<< 2.02+dfsg1-7), grub-efi-ia64 (<< 2.02+dfsg1-7), grub-efi-arm (<< 2.02+dfsg1-7), grub-efi-arm64 (<< 2.02+dfsg1-7), grub-ieee1275 (<< 2.02+dfsg1-7), grub-uboot (<< 2.02+dfsg1-7), grub-xen (<< 2.02+dfsg1-7), grub-yeeloong (<< 2.02+dfsg1-7), grub-cloud-amd64 (<< 0.0.4)
@@ -789,6 +789,78 @@ Description: GRand Unified Bootloader, version 2 (loong64 UEFI version)
  use on Loongarch 64-bit systems with UEFI.  Installing this package indicates that
  this version of GRUB should be the active boot loader.
 
+Package: grub-efi-sw64-bin
+Architecture: sw64
+Depends: ${shlibs:Depends}, ${misc:Depends}, grub-common (>= 2.02~beta2-9), grub-efi-sw64-unsigned
+Recommends: efibootmgr [linux-any], grub-efi-sw64-unsigned
+Multi-Arch: foreign
+XB-Efi-Vendor: ${efi:Vendor}
+Description: GRand Unified Bootloader, version 2 (sw64 UEFI modules)
+ GRUB is a portable, powerful bootloader.  This version of GRUB is based on a
+ cleaner design than its predecessors, and provides the following new features:
+ .
+  - Scripting in grub.cfg using BASH-like syntax.
+  - Support for modern partition maps such as GPT.
+  - Modular generation of grub.cfg via update-grub.  Packages providing GRUB
+    add-ons can plug in their own script rules and trigger updates by invoking
+    update-grub.
+ .
+ This package contains GRUB modules that have been built for use on sw64
+ systems with UEFI.  It can be installed in parallel with other flavours,
+ but will not automatically install GRUB as the active boot loader nor
+ automatically update grub.cfg on upgrade unless grub-efi-sw64 is also
+ installed.
+
+Package: grub-efi-sw64-unsigned
+Architecture: sw64
+Depends: ${shlibs:Depends}, ${misc:Depends}, grub-common (>= 2.02~beta2-9)
+Recommends: efibootmgr [linux-any]
+Multi-Arch: foreign
+XB-Efi-Vendor: ${efi:Vendor}
+Description: GRand Unified Bootloader, version 2 (sw64 UEFI images)
+ GRUB is a portable, powerful bootloader.  This version of GRUB is based on a
+ cleaner design than its predecessors, and provides the following new features:
+ .
+  - Scripting in grub.cfg using BASH-like syntax.
+  - Support for modern partition maps such as GPT.
+  - Modular generation of grub.cfg via update-grub.  Packages providing GRUB
+    add-ons can plug in their own script rules and trigger updates by invoking
+    update-grub.
+ .
+ This package contains GRUB images that have been built for use on sw64
+ systems with UEFI.  It can be installed in parallel with other flavours,
+ but will not automatically install GRUB as the active boot loader nor
+ automatically update grub.cfg on upgrade unless grub-efi-sw64 is also
+ installed.
+
+Package: grub-efi-sw64-dbg
+Section: debug
+Architecture: sw64
+Depends: ${misc:Depends}, grub-efi-sw64-bin (= ${binary:Version})
+Multi-Arch: foreign
+Description: GRand Unified Bootloader, version 2 (sw64 UEFI debug files)
+ This package contains debugging files for grub-efi-sw64-bin.  You only
+ need these if you are trying to debug GRUB using its GDB stub.
+
+Package: grub-efi-sw64
+Architecture: sw64
+Pre-Depends: ${misc:Pre-Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}, grub2-common (>= 2.02~beta2-9), grub-efi-sw64-bin (= ${binary:Version}), grub-efi-sw64-unsigned (= ${binary:Version}), ucf
+Multi-Arch: foreign
+Description: GRand Unified Bootloader, version 2 (sw64 UEFI version)
+ GRUB is a portable, powerful bootloader.  This version of GRUB is based on a
+ cleaner design than its predecessors, and provides the following new features:
+ .
+  - Scripting in grub.cfg using BASH-like syntax.
+  - Support for modern partition maps such as GPT.
+  - Modular generation of grub.cfg via update-grub.  Packages providing GRUB
+    add-ons can plug in their own script rules and trigger updates by invoking
+    update-grub.
+ .
+ This is a dependency package for a version of GRUB that has been built for
+ use on SW64 systems with UEFI.  Installing this package indicates that
+ this version of GRUB should be the active boot loader.
+
 Package: grub-efi-mips64el-bin
 Architecture: any-mips64el
 Depends: ${shlibs:Depends}, ${misc:Depends}, grub-common
@@ -1078,7 +1150,7 @@ Description: GRand Unified Bootloader, version 2 (Yeeloong version)
 Package: grub-theme-starfield
 # Could be Architecture: any, but in practice this package is useless in a
 # utilities-only build.
-Architecture: any-i386 any-amd64 any-powerpc any-ppc64 any-ppc64el any-sparc any-sparc64 any-mipsel any-ia64 any-arm any-arm64 any-riscv64 any-loong64 any-mips64el
+Architecture: any-i386 any-amd64 any-powerpc any-ppc64 any-ppc64el any-sparc any-sparc64 any-mipsel any-ia64 any-arm any-arm64 any-riscv64 any-loong64 any-mips64el sw64
 Depends: ${misc:Depends}, grub-common (= ${binary:Version})
 Multi-Arch: foreign
 Description: GRand Unified Bootloader, version 2 (starfield theme)

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -214,6 +214,13 @@ mips/0014-loader-mips64-linux-properly-prepare-memory-for-init.patch
 mips/0015-fix-util-grub-mkimagexx-unconditionaly-use-64-bit-ad.patch
 uniontech-mips-set-lang-c.patch
 
+# SW64 support
+sw64/0001-sw64-Add-early-startup-code.patch
+sw64/0002-sw64-Add-Linux-load-logic.patch
+sw64/0003-sw64-Add-awareness-for-SW64-reloations.patch
+sw64/0004-sw64-Add-auxiliary-files.patch
+sw64/0005-sw64-Add-to-build-system.patch
+
 # backport: fix riscv64 rdcycle
 use-time-register-in-grub_efi_get_time_ms.patch
 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -220,6 +220,8 @@ sw64/0002-sw64-Add-Linux-load-logic.patch
 sw64/0003-sw64-Add-awareness-for-SW64-reloations.patch
 sw64/0004-sw64-Add-auxiliary-files.patch
 sw64/0005-sw64-Add-to-build-system.patch
+sw64/0006-sw64-drop-all-efi_call-wrappers.patch
+sw64/0007-sw64-fix-efi-and-peimage-build-issues.patch
 
 # backport: fix riscv64 rdcycle
 use-time-register-in-grub_efi_get_time_ms.patch

--- a/debian/patches/sw64/0001-sw64-Add-early-startup-code.patch
+++ b/debian/patches/sw64/0001-sw64-Add-early-startup-code.patch
@@ -1,0 +1,59 @@
+From 884e61f725f2586a3ddccfa86d6162dd08291ec0 Mon Sep 17 00:00:00 2001
+From: sunway_fw <sunway_fw@wxiat.com>
+Date: Thu, 14 May 2026 08:46:14 +0800
+Subject: [PATCH 1/4] sw64: Add early startup code
+
+On entry, we need to save the system table pointer as well as our image
+handle. Add an early startup file that saves them and then brings us
+into our main function.
+
+Signed-off-by: sunway_fw <sunway_fw@wxiat.com>
+---
+ grub-core/kern/sw64/efi/startup.S | 35 +++++++++++++++++++++++++++++++
+ 1 file changed, 35 insertions(+)
+ create mode 100644 grub-core/kern/sw64/efi/startup.S
+
+diff --git a/grub-core/kern/sw64/efi/startup.S b/grub-core/kern/sw64/efi/startup.S
+new file mode 100644
+index 0000000..d3b3681
+--- /dev/null
++++ b/grub-core/kern/sw64/efi/startup.S
+@@ -0,0 +1,35 @@
++/*
++ *  GRUB  --  GRand Unified Bootloader
++ *  Copyright (C) 2026  Free Software Foundation, Inc.
++ *
++ *  GRUB is free software: you can redistribute it and/or modify
++ *  it under the terms of the GNU General Public License as published by
++ *  the Free Software Foundation, either version 3 of the License, or
++ *  (at your option) any later version.
++ *
++ *  GRUB is distributed in the hope that it will be useful,
++ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *  GNU General Public License for more details.
++ *
++ *  You should have received a copy of the GNU General Public License
++ *  along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++#include <grub/symbol.h>
++#include <grub/sw64/regdef.h>
++
++       .file   "startup.S"
++       .text
++FUNCTION(_start)
++       /*
++        *  EFI_SYSTEM_TABLE and EFI_HANDLE are passed in a1/a0.
++        */
++       ldih    $29,0($27) !gpdisp!1
++       ldi     $29,0($29) !gpdisp!1
++       ldi     $20, EXT_C(grub_efi_image_handle)
++       stl     a0, 0($20)
++       ldi     $20, EXT_C(grub_efi_system_table)
++       stl     a1,  0($20)
++       call    $31, grub_main
++       ret
+-- 
+2.20.1
+

--- a/debian/patches/sw64/0002-sw64-Add-Linux-load-logic.patch
+++ b/debian/patches/sw64/0002-sw64-Add-Linux-load-logic.patch
@@ -1,0 +1,612 @@
+From 0b5a59ddf5d6fd0589b43fdff4fd1226423b2252 Mon Sep 17 00:00:00 2001
+From: sunway_fw <sunway_fw@wxiat.com>
+Date: Thu, 14 May 2026 10:59:23 +0800
+Subject: [PATCH 2/4] sw64: Add Linux load logic
+
+We currently only support to run grub on SW64 as UEFI payload. Ideally,
+we also only want to support running Linux underneath as UEFI payload.
+
+Signed-off-by: sunway_fw <sunway_fw@wxiat.com>
+---
+ grub-core/loader/sw64/efi/linux.c | 535 ++++++++++++++++++++++++++++++
+ include/grub/sw64/linux.h         |  46 +++
+ 2 files changed, 581 insertions(+)
+ create mode 100644 grub-core/loader/sw64/efi/linux.c
+ create mode 100644 include/grub/sw64/linux.h
+
+diff --git a/grub-core/loader/sw64/efi/linux.c b/grub-core/loader/sw64/efi/linux.c
+new file mode 100644
+index 0000000..fd2d713
+--- /dev/null
++++ b/grub-core/loader/sw64/efi/linux.c
+@@ -0,0 +1,535 @@
++/*
++ *  GRUB  --  GRand Unified Bootloader
++ *  Copyright (C) 2026  Free Software Foundation, Inc.
++ *
++ *  GRUB is free software: you can redistribute it and/or modify
++ *  it under the terms of the GNU General Public License as published by
++ *  the Free Software Foundation, either version 3 of the License, or
++ *  (at your option) any later version.
++ *
++ *  GRUB is distributed in the hope that it will be useful,
++ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *  GNU General Public License for more details.
++ *
++ *  You should have received a copy of the GNU General Public License
++ *  along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++#include <grub/loader.h>
++#include <grub/file.h>
++#include <grub/disk.h>
++#include <grub/err.h>
++#include <grub/misc.h>
++#include <grub/types.h>
++#include <grub/command.h>
++#include <grub/dl.h>
++#include <grub/mm.h>
++#include <grub/cache.h>
++#include <grub/kernel.h>
++#include <grub/efi/api.h>
++#include <grub/efi/fdtload.h>
++#include <grub/efi/efi.h>
++#include <grub/elf.h>
++#include <grub/elfload.h>
++#include <grub/i18n.h>
++#include <grub/env.h>
++#include <grub/cpu/linux.h>
++#include <grub/lib/cmdline.h>
++#include <grub/linux.h>
++#include <grub/fdt.h>
++#include <grub/efi/memory.h>
++
++GRUB_MOD_LICENSE ("GPLv3+");
++
++#pragma GCC diagnostic ignored "-Wcast-align"
++
++#define GRUB_EFI_SW64_FIRMWARE_INFO  { 0xc47a23c3, 0xcebb, 0x4cc9, \
++       { 0xa5, 0xe2, 0xde, 0xd0, 0x8f, 0xe4, 0x20, 0xb5 } }
++
++#define GRUB_EFI_SW64_MEMORY_ATTRIBUTES  { 0xdcfa911d, 0x26eb, 0x469f, \
++       { 0xa2, 0x20, 0x38, 0xb7, 0xdc, 0x46, 0x12, 0x20 } }
++
++#define SW64_EFI_FIRMWARE_INFO_SIGNATURE        \
++         ('S' << 24 | 'H' << 16 | 'I' << 8 | 'F')
++
++static grub_dl_t my_mod;
++static int loaded;
++static char *linux_args;
++
++/* Initrd base and size.  */
++static void *initrd_mem;
++static grub_efi_uintn_t initrd_pages;
++static grub_addr_t initrd_start;
++static grub_efi_uintn_t initrd_size;
++static grub_uint64_t linux_entry;
++
++struct sw64_firmware_info_head
++{
++  grub_uint32_t signature;
++  grub_uint32_t revision;
++  grub_uint32_t length;
++};
++
++struct sw64_firmware_info
++{
++  struct sw64_firmware_info_head firmware_info_head;
++  grub_uint32_t reserved;
++  grub_uint32_t need_boot_param;
++};
++
++void *raw_fdt;
++static struct boot_param *sunway_boot_params = (struct boot_param *)BOOT_PARAM_START;
++
++static grub_efi_uint32_t
++sw64_efi_get_boot_param (void)
++{
++  unsigned i;
++  struct sw64_firmware_info_head *firmware_info_head;
++  static grub_packed_guid_t info_guid = GRUB_EFI_SW64_FIRMWARE_INFO;
++
++  for (i = 0; i < grub_efi_system_table->num_table_entries; i++)
++    {
++      grub_packed_guid_t *guid =
++        (grub_packed_guid_t *)&grub_efi_system_table->configuration_table[i].vendor_guid;
++
++      if (! grub_memcmp (guid, &info_guid, sizeof (grub_packed_guid_t)))
++      {
++        firmware_info_head = grub_efi_system_table->configuration_table[i].vendor_table;
++        if (firmware_info_head->signature != SW64_EFI_FIRMWARE_INFO_SIGNATURE) {
++	  /*
++	   * No matching SW64 firmware info table found.
++	   * Return 1 intentionally to fall back to legacy boot parameter handling.
++	   * This covers platforms without the specific GUID or with older firmware.
++	   */
++          return 1;
++        }
++
++        if (firmware_info_head->revision == 1) {
++          return ((struct sw64_firmware_info *)firmware_info_head)->need_boot_param;
++        }
++      }
++    }
++  return 1;
++}
++
++static void
++sw64_efi_memattr_repair (void)
++{
++  unsigned i;
++  static grub_packed_guid_t info_guid = GRUB_EFI_SW64_MEMORY_ATTRIBUTES;
++
++  for (i = 0; i < grub_efi_system_table->num_table_entries; i++) {
++    grub_packed_guid_t *guid = (grub_packed_guid_t *)&grub_efi_system_table->configuration_table[i].vendor_guid;
++
++    if (! grub_memcmp (guid, &info_guid, sizeof (grub_packed_guid_t))) {
++      grub_efi_system_table->configuration_table[i].vendor_table = (void *)grub_virt_to_phys((grub_uint64_t)grub_efi_system_table->configuration_table[i].vendor_table);
++    }
++  }
++}
++
++typedef
++void
++(*jump_to_kernel) (
++  grub_uint64_t magic,
++  grub_uint64_t device_tree_base
++  );
++
++static grub_err_t
++finalize_params_linux (void)
++{
++  int retval;
++  int node;
++  grub_efi_uintn_t mmap_size;
++  grub_efi_uintn_t map_key;
++  grub_efi_uintn_t desc_size;
++  grub_efi_uint32_t desc_version;
++  grub_efi_memory_descriptor_t *mmap_buf;
++  grub_efi_uintn_t i;
++  grub_uint32_t bootargs_size;
++  const char *last_bootargs;
++  static char *temp_linux_args;
++
++  mmap_buf = 0;
++
++  raw_fdt = grub_fdt_load (GRUB_EFI_LINUX_FDT_EXTRA_SPACE);
++
++  if (!raw_fdt || grub_fdt_check_header_nosize(raw_fdt)) {
++    goto failure;
++  }
++
++  node = grub_fdt_find_subnode (raw_fdt, 0, "chosen");
++  if (node < 0)
++    node = grub_fdt_add_subnode (raw_fdt, 0, "chosen");
++
++  if (node < 1)
++    goto failure;
++
++  initrd_start  = grub_virt_to_phys (initrd_start);
++
++  if (initrd_start) {
++    retval = grub_fdt_set_prop64 (raw_fdt, node, "linux,initrd-start", initrd_start);
++    if (retval)
++      goto failure;
++
++    retval = grub_fdt_set_prop64 (raw_fdt, node, "linux,initrd-end", initrd_start + initrd_size);
++    if (retval)
++      goto failure;
++  }
++
++  last_bootargs = grub_fdt_get_prop (raw_fdt, node, "bootargs", &bootargs_size);
++  if (last_bootargs && grub_strlen (last_bootargs) > 1) {
++    temp_linux_args = grub_malloc (grub_strlen (linux_args) + bootargs_size + 1);
++    if (!temp_linux_args)
++    {
++      grub_error (GRUB_ERR_OUT_OF_MEMORY, N_("out of memory in finalize_params_linux"));
++      goto failure;
++    }
++    grub_memcpy (temp_linux_args, last_bootargs, bootargs_size - 1);
++    *(temp_linux_args + bootargs_size - 1) = ' ';
++    grub_memcpy (temp_linux_args + bootargs_size, linux_args, grub_strlen (linux_args) + 1);
++    grub_free (linux_args);
++    linux_args = temp_linux_args;
++  }
++
++  retval = grub_fdt_set_prop (raw_fdt, node, "bootargs", linux_args, grub_strlen (linux_args) + 1);
++  if (retval)
++    goto failure;
++
++  retval = grub_fdt_set_prop64 (raw_fdt, node, "linux,uefi-system-table",
++                                grub_virt_to_phys((grub_uint64_t)grub_efi_system_table));
++  if (retval)
++    goto failure;
++
++  mmap_size = grub_efi_find_mmap_size ();
++  if (! mmap_size)
++    goto failure;
++
++  mmap_buf = grub_efi_allocate_any_pages (GRUB_EFI_BYTES_TO_PAGES (mmap_size));
++  if (! mmap_buf)
++    goto failure;
++
++  grub_efi_finish_boot_services (&mmap_size, mmap_buf, &map_key, &desc_size, &desc_version);
++
++  retval = grub_fdt_set_prop64 (raw_fdt, node, "linux,uefi-mmap-start",
++      grub_virt_to_phys((grub_uint64_t)mmap_buf));
++
++  retval = grub_fdt_set_prop64 (raw_fdt, node, "linux,uefi-mmap-size", mmap_size);
++  if (retval)
++    goto failure_without_dprintf;
++
++  retval = grub_fdt_set_prop64 (raw_fdt, node, "linux,uefi-mmap-desc-size", desc_size);
++  if (retval)
++    goto failure_without_dprintf;
++
++  retval = grub_fdt_set_prop64 (raw_fdt, node, "linux,uefi-mmap-desc-ver", desc_version);
++  if (retval)
++    goto failure_without_dprintf;
++
++  for (i = 0; i < mmap_size / desc_size; i++) {
++    grub_efi_memory_descriptor_t *curdesc = (grub_efi_memory_descriptor_t *)
++      ((char *) mmap_buf + desc_size * i);
++
++    curdesc->physical_start = grub_virt_to_phys(curdesc->physical_start);
++  }
++
++  sw64_efi_memattr_repair();
++
++  return GRUB_ERR_NONE;
++
++failure:
++  grub_dprintf ("linux", "something went wrong in finalize_params_linux\n");
++
++failure_without_dprintf:
++  raw_fdt = 0;
++  return GRUB_ERR_BAD_OS;
++}
++
++static grub_err_t
++legacy_finalize_params_linux (void)
++{
++  grub_efi_uintn_t mmap_size;
++  grub_efi_uintn_t map_key;
++  grub_efi_uintn_t desc_size;
++  grub_efi_uint32_t desc_version;
++  grub_efi_memory_descriptor_t *mmap_buf;
++  grub_err_t err;
++  grub_efi_uintn_t i;
++
++  /* Initrd.  */
++  sunway_boot_params->initrd_start = (grub_uint64_t)initrd_start;
++  sunway_boot_params->initrd_size = (grub_uint64_t)initrd_size;
++
++  /* DTB. */
++  raw_fdt = grub_fdt_load (GRUB_EFI_LINUX_FDT_EXTRA_SPACE);
++
++  if (!raw_fdt)
++    {
++      sunway_boot_params->dtb_start = 0;
++      grub_dprintf ("linux", "not found registered FDT\n");
++    }
++
++  if (raw_fdt)
++    {
++      err = grub_fdt_check_header_nosize(raw_fdt);
++      if (err)
++	grub_dprintf ("linux", "illegal FDT file\n");
++
++      sunway_boot_params->dtb_start = (grub_uint64_t)raw_fdt;
++      grub_dprintf ("linux", "dtb: [addr=0x%lx, size=0x%x]\n",
++		      (grub_uint64_t) raw_fdt, grub_fdt_get_totalsize(raw_fdt));
++    }
++
++  /* MDT.
++     Must be done after grub_machine_fini because map_key is used by
++     exit_boot_services.  */
++  mmap_size = grub_efi_find_mmap_size ();
++  if (! mmap_size) {
++    grub_dprintf ("linux", "unable to get mmap_size\n");
++    return GRUB_ERR_BAD_OS;
++  }
++  mmap_buf = grub_efi_allocate_any_pages (GRUB_EFI_BYTES_TO_PAGES (mmap_size));
++  if (! mmap_buf) {
++    grub_dprintf ("linux", "cannot allocate memory map\n");
++    return GRUB_ERR_BAD_OS;
++  }
++  err = grub_efi_finish_boot_services (&mmap_size, mmap_buf, &map_key,
++                                       &desc_size, &desc_version);
++  for (i = 0; i < mmap_size / desc_size; i++)
++    {
++      grub_efi_memory_descriptor_t *curdesc = (grub_efi_memory_descriptor_t *)
++        ((char *) mmap_buf + desc_size * i);
++
++      curdesc->physical_start = grub_virt_to_phys(curdesc->physical_start);
++    }
++
++  sw64_efi_memattr_repair();
++
++  sunway_boot_params->command_line = (grub_uint64_t) linux_args;
++  sunway_boot_params->efi_systab = grub_virt_to_phys((grub_uint64_t)grub_efi_system_table);
++  sunway_boot_params->efi_memmap = grub_virt_to_phys((grub_uint64_t)mmap_buf);
++  sunway_boot_params->efi_memmap_size = mmap_size;
++  sunway_boot_params->efi_memdesc_size = desc_size;
++  sunway_boot_params->efi_memdesc_version = desc_version;
++
++  return GRUB_ERR_NONE;
++}
++static void
++start_kernel(void)
++{
++  grub_dprintf ("linux", "Jump to entry: %lx\n", linux_entry);
++
++  jump_to_kernel jump = (jump_to_kernel) linux_entry;
++  if (sw64_efi_get_boot_param()) {
++    jump (0, 0);
++  } else {
++    jump (0xdeed2024, (grub_uint64_t)raw_fdt);
++  }
++}
++
++static grub_err_t
++grub_linux_boot (void)
++{
++  if (sw64_efi_get_boot_param()) {
++    legacy_finalize_params_linux();
++  } else {
++    finalize_params_linux();
++  }
++
++  start_kernel ();
++  return GRUB_ERR_NONE;
++}
++
++static grub_err_t
++grub_linux_unload (void)
++{
++  grub_free (linux_args);
++  linux_args = NULL;
++  if (initrd_mem)
++    {
++      grub_efi_free_pages ((grub_addr_t) initrd_mem, initrd_pages);
++      initrd_mem = NULL;
++      initrd_start = 0;
++    }
++  loaded = 0;
++  grub_dl_unref (my_mod);
++  return GRUB_ERR_NONE;
++}
++
++static grub_err_t
++grub_load_elf64 (grub_elf_t elf, const char *filename)
++{
++  Elf64_Addr base_addr;
++  grub_size_t linux_size;
++  grub_uint64_t align;
++
++  if (elf->ehdr.ehdr64.e_ident[EI_MAG0] != ELFMAG0
++      || elf->ehdr.ehdr64.e_ident[EI_MAG1] != ELFMAG1
++      || elf->ehdr.ehdr64.e_ident[EI_MAG2] != ELFMAG2
++      || elf->ehdr.ehdr64.e_ident[EI_MAG3] != ELFMAG3
++      || elf->ehdr.ehdr64.e_ident[EI_DATA] != ELFDATA2LSB)
++    return grub_error(GRUB_ERR_UNKNOWN_OS,
++		      N_("invalid arch-independent ELF magic"));
++
++  if (elf->ehdr.ehdr64.e_ident[EI_CLASS] != ELFCLASS64
++      || elf->ehdr.ehdr64.e_version != EV_CURRENT
++      || elf->ehdr.ehdr64.e_machine != EM_SW_64)
++    return grub_error (GRUB_ERR_UNKNOWN_OS,
++		       N_("invalid arch-dependent ELF magic"));
++
++  if (elf->ehdr.ehdr64.e_type != ET_EXEC)
++    return grub_error (GRUB_ERR_UNKNOWN_OS,
++		       N_("this ELF file is not of the right type"));
++
++  /* FIXME: Should we support program headers at strange locations?  */
++  if (elf->ehdr.ehdr64.e_phoff + elf->ehdr.ehdr64.e_phnum * elf->ehdr.ehdr64.e_phentsize > GRUB_ELF_SEARCH)
++    return grub_error (GRUB_ERR_BAD_OS, "program header at a too high offset");
++
++  linux_size = grub_elf64_size (elf, &base_addr, &align);
++  if (linux_size == 0)
++    return grub_error (GRUB_ERR_BAD_OS, "linux size is 0");
++
++  linux_entry = (grub_uint64_t)elf->ehdr.ehdr64.e_entry;
++  grub_dprintf ("linux", "Segment phy_addr: %lx  entry: %lx\n", (grub_uint64_t)base_addr,(grub_uint64_t)elf->ehdr.ehdr64.e_entry);
++
++  /* Now load the segments into the area we claimed.  */
++  return grub_elf64_load (elf, filename, (void *) (grub_addr_t) (0), GRUB_ELF_LOAD_FLAGS_NONE, 0, 0);
++}
++
++static grub_err_t
++grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
++		int argc, char *argv[])
++{
++  grub_ssize_t size;
++  grub_elf_t elf = 0;
++
++  grub_dl_ref (my_mod);
++
++  grub_loader_unset ();
++
++  if (argc == 0)
++    {
++      grub_error (GRUB_ERR_BAD_ARGUMENT, N_("filename expected"));
++      goto fail;
++    }
++
++  elf = grub_elf_open (argv[0], GRUB_FILE_TYPE_LINUX_KERNEL);
++  if (! elf)
++    goto fail;
++
++  grub_dprintf ("linux", "Loading linux: %s\n", argv[0]);
++
++  if (grub_load_elf64 (elf, argv[0]))
++    goto fail;
++
++  grub_memset (sunway_boot_params, 0, sizeof(*sunway_boot_params));
++  size = grub_loader_cmdline_size(argc, argv);
++
++  linux_args = grub_malloc (size + sizeof (LINUX_IMAGE));
++  if (!linux_args)
++    {
++      grub_error (GRUB_ERR_OUT_OF_MEMORY, N_("out of memory"));
++      goto fail;
++    }
++
++  /* Create kernel command line.  */
++  grub_memcpy (linux_args, LINUX_IMAGE, sizeof (LINUX_IMAGE));
++  grub_create_loader_cmdline (argc, argv, linux_args + sizeof (LINUX_IMAGE) - 1,
++                              size, GRUB_VERIFY_KERNEL_CMDLINE);
++
++  grub_dprintf ("linux", "linux_args: '%s'\n", linux_args);
++  grub_errno = GRUB_ERR_NONE;
++
++  grub_loader_set (grub_linux_boot, grub_linux_unload, 0);
++
++ fail:
++  if (elf)
++    grub_elf_close (elf);
++
++  if (grub_errno != GRUB_ERR_NONE)
++    {
++      grub_dl_unref (my_mod);
++      loaded = 0;
++
++      grub_free (linux_args);
++      linux_args = NULL;
++    }
++  else
++    loaded = 1;
++
++  return grub_errno;
++}
++
++static grub_err_t
++grub_cmd_initrd (grub_command_t cmd __attribute__ ((unused)),
++		 int argc, char *argv[])
++{
++  if (initrd_mem)
++  {
++    grub_efi_free_pages ((grub_addr_t) initrd_mem, initrd_pages);
++    initrd_mem = NULL;
++    initrd_start = 0;
++  }
++
++  struct grub_linux_initrd_context initrd_ctx = { 0, 0, 0 };
++
++  if (argc == 0)
++    {
++      grub_error (GRUB_ERR_BAD_ARGUMENT, N_("filename expected"));
++      goto fail;
++    }
++
++  if (! loaded)
++    {
++      grub_error (GRUB_ERR_BAD_ARGUMENT, N_("you need to load the kernel first"));
++      goto fail;
++    }
++
++  if (grub_initrd_init (argc, argv, &initrd_ctx))
++    goto fail;
++
++  initrd_size = grub_get_initrd_size (&initrd_ctx);
++  grub_dprintf ("linux", "Loading initrd %s\n", argv[0]);
++
++  initrd_pages = (GRUB_EFI_BYTES_TO_PAGES (initrd_size));
++  initrd_mem = grub_efi_allocate_any_pages (initrd_pages);
++  if (! initrd_mem)
++    {
++      grub_error (GRUB_ERR_OUT_OF_MEMORY, "cannot allocate pages");
++      goto fail;
++    }
++
++  grub_dprintf ("linux", "initrd: [addr=0x%lx, size=0x%lx]\n",
++                (grub_uint64_t) initrd_mem, initrd_size);
++
++  if (grub_initrd_load (&initrd_ctx, initrd_mem))
++    goto fail;
++
++  initrd_start = (grub_addr_t) initrd_mem;
++
++ fail:
++  grub_initrd_close (&initrd_ctx);
++  if (initrd_mem && !initrd_start)
++    grub_efi_free_pages ((grub_addr_t) initrd_mem, initrd_pages);
++
++  return grub_errno;
++}
++
++static grub_command_t cmd_linux, cmd_initrd;
++
++GRUB_MOD_INIT (linux)
++{
++  cmd_linux = grub_register_command ("linux", grub_cmd_linux,
++				     N_("FILE [ARGS...]"), N_("Load Linux."));
++
++  cmd_initrd = grub_register_command ("initrd", grub_cmd_initrd,
++				      N_("FILE"), N_("Load initrd."));
++
++  my_mod = mod;
++}
++
++GRUB_MOD_FINI (linux)
++{
++  grub_unregister_command (cmd_linux);
++  grub_unregister_command (cmd_initrd);
++}
+diff --git a/include/grub/sw64/linux.h b/include/grub/sw64/linux.h
+new file mode 100644
+index 0000000..89f2ce1
+--- /dev/null
++++ b/include/grub/sw64/linux.h
+@@ -0,0 +1,46 @@
++#ifndef GRUB_SW_H
++#define GRUB_SW_H	1
++#define PAGE_OFFSET		0xfff0000000000000UL
++#define KTEXT_OFFSET		0xffffffff80000000UL
++#define GRUB_PRINTK_START       (PAGE_OFFSET | 0x800000)
++#define GRUB_PRINTK_SIZE	(0x20000)
++
++/* Hardcoded boot parameter address. Must match firmware/Kernel layout.
++ * If changed, GRUB may write to wrong memory.
++ */
++#define BOOT_PARAM_START	0xfff000000090a100ULL
++
++#define GRUB_ELF_SEARCH         1024
++
++static inline
++grub_uint64_t
++grub_virt_to_phys(grub_uint64_t x)
++{
++  if (x >= KTEXT_OFFSET)
++    x -= KTEXT_OFFSET;
++  else if (x >= PAGE_OFFSET)
++    x -= PAGE_OFFSET;
++
++  return x;
++}
++
++struct boot_param
++{
++  grub_uint64_t initrd_start;                   /* logical address of initrd */
++  grub_uint64_t initrd_size;                    /* size of initrd */
++  grub_uint64_t dtb_start;                      /* logical address of dtb */
++  grub_uint64_t efi_systab;                     /* logical address of EFI system table */
++  grub_uint64_t efi_memmap;                     /* logical address of EFI memory map */
++  grub_uint64_t efi_memmap_size;                /* size of EFI memory map */
++  grub_uint64_t efi_memdesc_size;               /* size of an EFI memory map descriptor */
++  grub_uint64_t efi_memdesc_version;            /* memory descriptor version */
++  grub_uint64_t command_line;                   /* logical address of cmdline */
++};
++
++struct linux_sw64_kernel_header
++{
++};
++
++#define linux_arch_kernel_header linux_sw64_kernel_header
++
++#endif
+-- 
+2.20.1
+

--- a/debian/patches/sw64/0003-sw64-Add-awareness-for-SW64-reloations.patch
+++ b/debian/patches/sw64/0003-sw64-Add-awareness-for-SW64-reloations.patch
@@ -1,0 +1,544 @@
+From f05360e9f8ab302bf1c4eef275e163c5a6b5f9b6 Mon Sep 17 00:00:00 2001
+From: sunway_fw <sunway_fw@wxiat.com>
+Date: Thu, 14 May 2026 11:18:49 +0800
+Subject: [PATCH 3/4] sw64: Add awareness for SW64 reloations
+
+This patch adds awareness of SW64 relocations throughout the grub tools
+as well as dynamic linkage and elf->PE relocation conversion support.
+
+Signed-off-by: sunway_fw <sunway_fw@wxiat.com>
+---
+ grub-core/kern/sw64/dl.c    | 214 ++++++++++++++++++++++++++++++++++++
+ include/grub/dl.h           |  13 +++
+ include/grub/elf.h          |  38 +++++++
+ util/grub-mkimagexx.c       | 145 +++++++++++++++++++++++-
+ util/grub-module-verifier.c |  20 ++++
+ 5 files changed, 429 insertions(+), 1 deletion(-)
+ create mode 100644 grub-core/kern/sw64/dl.c
+
+diff --git a/grub-core/kern/sw64/dl.c b/grub-core/kern/sw64/dl.c
+new file mode 100644
+index 0000000..682e60a
+--- /dev/null
++++ b/grub-core/kern/sw64/dl.c
+@@ -0,0 +1,214 @@
++/* dl.c - arch-dependent part of loadable module support */
++/*
++ *  GRUB  --  GRand Unified Bootloader
++ *  Copyright (C) 2026  Free Software Foundation, Inc.
++ *
++ *  GRUB is free software: you can redistribute it and/or modify
++ *  it under the terms of the GNU General Public License as published by
++ *  the Free Software Foundation, either version 3 of the License, or
++ *  (at your option) any later version.
++ *
++ *  GRUB is distributed in the hope that it will be useful,
++ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *  GNU General Public License for more details.
++ *
++ *  You should have received a copy of the GNU General Public License
++ *  along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++#include <grub/dl.h>
++#include <grub/elf.h>
++#include <grub/misc.h>
++#include <grub/err.h>
++#include <grub/mm.h>
++#include <grub/i18n.h>
++#include <grub/elf.h>
++
++/*
++ * Check if EHDR is a valid ELF header.
++ */
++grub_err_t
++grub_arch_dl_check_header (void *ehdr)
++{
++  Elf_Ehdr *e = ehdr;
++
++  /* Check the magic numbers.  */
++  if (e->e_ident[EI_DATA] != ELFDATA2LSB || e->e_machine != EM_SW_64)
++    return grub_error (GRUB_ERR_BAD_OS,
++		       N_("invalid arch-dependent ELF magic"));
++
++  return GRUB_ERR_NONE;
++}
++
++#pragma GCC diagnostic ignored "-Wcast-align"
++
++/* Relocate symbols. */
++grub_err_t
++grub_arch_dl_relocate_symbols (grub_dl_t mod, void *ehdr,
++                               Elf_Shdr *s, grub_dl_segment_t seg)
++{
++  Elf_Rela *rel, *max;
++  grub_uint64_t *gpptr, *gotptr;
++
++  gotptr = (grub_uint64_t *) mod->got;
++  gpptr = (grub_uint64_t *) ((grub_uint64_t) mod->got + 0x8000);
++
++  for (rel = (Elf_Rela *) ((char *) ehdr + s->sh_offset),
++         max = (Elf_Rela *) ((char *) rel + s->sh_size);
++       rel < max;
++       rel = (Elf_Rela *) ((char *) rel + s->sh_entsize))
++    {
++      grub_addr_t addr;
++      Elf_Sym *sym;
++      grub_uint64_t value;
++
++      if (seg->size < (rel->r_offset & ~3))
++              return grub_error (GRUB_ERR_BAD_MODULE,
++                              "reloc offset is out of the segment");
++
++      addr = (grub_addr_t) seg->addr + rel->r_offset;
++      sym = (Elf_Sym *) ((char *) mod->symtab
++                      + mod->symsize * ELF_R_SYM (rel->r_info));
++
++      /* On the SW64 the value does not have an explicit
++         addend, add it.  */
++      value = sym->st_value + rel->r_addend;
++
++      switch (ELF_R_TYPE (rel->r_info))
++        {
++        case R_SW64_NONE:
++          break;
++        case R_SW64_REFLONG:
++          *(grub_uint32_t *)addr = value;
++          break;
++        case R_SW64_REFQUAD:
++          {
++            *(grub_uint32_t *)addr = value;
++            *((grub_uint32_t *)addr + 1) = value >> 32;
++            break;
++          }
++        case R_SW64_GPREL32:
++          {
++            value -= (grub_uint64_t)gpptr;
++            if ((grub_int32_t)value != value)
++                    return grub_error (GRUB_ERR_BAD_MODULE,
++                                    "R_SW64_GPREL32 relocation out of range");
++            *(grub_uint32_t *) addr = value;
++            break;
++          }
++        case R_SW64_LITERAL:
++          {
++            grub_uint64_t li_hi;
++            grub_uint64_t li_lo;
++
++            li_hi = (grub_uint64_t) gotptr + (((grub_uint64_t)ELF_R_TYPE(rel->r_info)) >> 8 );
++            li_lo = li_hi - ((grub_uint64_t) gpptr);
++            if ((grub_int16_t)li_lo != li_lo)
++                    return grub_error (GRUB_ERR_BAD_MODULE,
++                                    "R_SW64_LITERAL relocation out of range");
++
++            *(grub_uint16_t *) addr = (li_lo & 0xffff);
++            *(grub_uint64_t *) (li_hi) = value;
++            gotptr++;
++            break;
++          }
++        case R_SW64_LITERAL_GOT:
++          break;
++        case R_SW64_LITUSE:
++          break;
++        case R_SW64_GPDISP:
++          {
++            grub_uint64_t hi;
++            grub_uint64_t lo;
++            grub_uint64_t gpoffset = (grub_int64_t)gpptr - addr;
++            lo = (grub_int16_t) gpoffset;
++            hi = (grub_int32_t) (gpoffset - lo);
++            if (hi + lo != gpoffset)
++                    return grub_error (GRUB_ERR_BAD_MODULE,
++                                    "R_SW64_GPDISP relocation out of range");
++
++            if (gpoffset & 0x8000) {
++                    hi = ((gpoffset + 0x8000) >> 16) & 0xffff;
++                    lo = gpoffset & 0xffff;
++            } else {
++                    hi = (gpoffset >> 16) & 0xffff;
++                    lo = gpoffset & 0xffff;
++            }
++
++            *(grub_uint32_t *) addr = ( *(grub_uint32_t *)addr & 0xffff0000) | (hi & 0xffff);
++            *(grub_uint32_t *) ((unsigned long)addr + rel->r_addend) =
++                    (((*(grub_uint32_t *)((unsigned long)addr + rel->r_addend)) & 0xffff0000) | (lo & 0xffff));
++            break;
++          }
++        case R_SW64_BRADDR:
++          {
++            grub_uint64_t braddr = (*(grub_uint64_t *)addr) + value - ((grub_uint64_t)addr + 4);
++            braddr = (grub_int64_t)braddr >> 2;
++            if (braddr + (1<<21) >= 1<<21)
++                    return grub_error (GRUB_ERR_BAD_MODULE,
++                                    "R_SW64_BRADDR relocation out of range");
++
++            *(grub_uint32_t *) addr = (*(grub_uint32_t *)addr & (~0x1fffff)) | (braddr & 0x1fffff);
++            break;
++          }
++        case R_SW64_HINT:
++          break;
++        case R_SW64_SREL32:
++          {
++            value -= (grub_uint64_t)addr;
++            if ((grub_int32_t)value != value)
++                    return grub_error (GRUB_ERR_BAD_MODULE,
++                                    "R_SW64_SREL32 relocation out of range");
++
++            *(grub_uint32_t *) addr = value;
++            break;
++          }
++        case R_SW64_SREL64:
++          {
++            grub_uint64_t srel64 = *(grub_uint64_t *)addr + value;;
++            srel64 -= (grub_uint64_t)addr;
++            *(grub_uint64_t *) addr = srel64;
++            break;
++          }
++        case R_SW64_GPRELHIGH:
++          {
++            grub_uint64_t gprel_hi = (grub_int64_t)(value - (grub_uint64_t)gpptr);
++
++            if (gprel_hi & 0x8000)
++                    gprel_hi = (grub_int64_t)(((grub_int64_t)gprel_hi + 0x8000) >> 16);
++            else
++                    gprel_hi = (grub_int64_t)gprel_hi >> 16;
++
++            if ((grub_int16_t)gprel_hi != gprel_hi)
++                    return grub_error (GRUB_ERR_BAD_MODULE,
++                                    "GPRELHIGH out of range\n");
++
++            *(grub_uint32_t *) addr = (*(grub_uint32_t *)addr & 0xffff0000) | (gprel_hi & 0xffff);
++            break;
++          }
++        case R_SW64_GPRELLOW:
++          {
++            grub_uint64_t gprel_lo = value - (grub_uint64_t)gpptr;
++            *(grub_uint32_t *) addr = (*(grub_uint32_t *)addr & 0xffff0000) | (gprel_lo & 0xffff);
++            break;
++          }
++        case R_SW64_GPREL16:
++          {
++            grub_uint64_t gprel16 = (*(grub_uint64_t *)addr + value);
++            gprel16 = (grub_uint64_t)(gprel16 - (grub_uint64_t)gpptr);
++            if ((grub_int16_t)gprel16 != gprel16)
++                    return grub_error (GRUB_ERR_BAD_MODULE,
++                                    "R_SW64_GPREL16 relocation out of range");
++            *(grub_uint16_t *) addr = gprel16;
++            break;
++          }
++        default:
++          return grub_error (GRUB_ERR_NOT_IMPLEMENTED_YET,
++                          N_("relocation 0x%lx is not implemented yet"),
++                          ELF_R_TYPE (rel->r_info));
++        }
++    }
++
++  return GRUB_ERR_NONE;
++}
+diff --git a/include/grub/dl.h b/include/grub/dl.h
+index cd1f46c..f316ab7 100644
+--- a/include/grub/dl.h
++++ b/include/grub/dl.h
+@@ -281,12 +281,25 @@ grub_err_t
+ grub_arm64_dl_get_tramp_got_size (const void *ehdr, grub_size_t *tramp,
+ 				  grub_size_t *got);
+ 
++#if defined (__sw_64__)
++#define GRUB_SW64_DL_TRAMP_ALIGN 16
++#define GRUB_SW64_DL_GOT_ALIGN 16
++
++grub_err_t
++grub_sw64_dl_get_tramp_got_size (const void *ehdr, grub_size_t *tramp,
++                                grub_size_t *got);
++#endif
++
+ #if defined (__ia64__)
+ #define GRUB_ARCH_DL_TRAMP_ALIGN GRUB_IA64_DL_TRAMP_ALIGN
+ #define GRUB_ARCH_DL_GOT_ALIGN GRUB_IA64_DL_GOT_ALIGN
+ #define grub_arch_dl_get_tramp_got_size grub_ia64_dl_get_tramp_got_size
+ #elif defined (__aarch64__)
+ #define grub_arch_dl_get_tramp_got_size grub_arm64_dl_get_tramp_got_size
++#elif defined (__sw_64__)
++#define GRUB_ARCH_DL_TRAMP_ALIGN GRUB_SW64_DL_TRAMP_ALIGN
++#define GRUB_ARCH_DL_GOT_ALIGN GRUB_SW64_DL_GOT_ALIGN
++#define grub_arch_dl_get_tramp_got_size grub_sw64_dl_get_tramp_got_size
+ #else
+ grub_err_t
+ grub_arch_dl_get_tramp_got_size (const void *ehdr, grub_size_t *tramp,
+diff --git a/include/grub/elf.h b/include/grub/elf.h
+index bd313a7..472b1bf 100644
+--- a/include/grub/elf.h
++++ b/include/grub/elf.h
+@@ -259,6 +259,7 @@ typedef struct
+    chances of collision with official or non-GNU unofficial values.  */
+ 
+ #define EM_ALPHA	0x9026
++#define EM_SW_64        0x9916
+ 
+ /* Legal values for e_version (version).  */
+ 
+@@ -2537,6 +2538,43 @@ typedef Elf32_Addr Elf32_Conflict;
+ #define R_RISCV_SET32           56
+ #define R_RISCV_32_PCREL        57
+ 
++/*
++ * SW-64 ELF relocation types
++ */
++#define R_SW64_NONE            0       /* No reloc */
++#define R_SW64_REFLONG         1       /* Direct 32 bit */
++#define R_SW64_REFQUAD         2       /* Direct 64 bit */
++#define R_SW64_GPREL32         3       /* GP relative 32 bit */
++#define R_SW64_LITERAL         4       /* GP relative 16 bit w/optimization */
++#define R_SW64_LITUSE          5       /* Optimization hint for LITERAL */
++#define R_SW64_GPDISP          6       /* Add displacement to GP */
++#define R_SW64_BRADDR          7       /* PC+4 relative 23 bit shifted */
++#define R_SW64_HINT            8       /* PC+4 relative 16 bit shifted */
++#define R_SW64_SREL32          10      /* PC relative 32 bit */
++#define R_SW64_SREL64          11      /* PC relative 64 bit */
++#define R_SW64_GPRELHIGH       17      /* GP relative 32 bit, high 16 bits */
++#define R_SW64_GPRELLOW        18      /* GP relative 32 bit, low 16 bits */
++#define R_SW64_GPREL16         19      /* GP relative 16 bit */
++#define R_SW64_COPY            24      /* Copy symbol at runtime */
++#define R_SW64_GLOB_DAT        25      /* Create GOT entry */
++#define R_SW64_JMP_SLOT        26      /* Create PLT entry */
++#define R_SW64_RELATIVE        27      /* Adjust by program base */
++#define R_SW64_BRSGP           28
++#define R_SW64_TLSGD           29
++#define R_SW64_TLS_LDM         30
++#define R_SW64_DTPMOD64        31
++#define R_SW64_GOTDTPREL       32
++#define R_SW64_DTPREL64        33
++#define R_SW64_DTPRELHI        34
++#define R_SW64_DTPRELLO        35
++#define R_SW64_DTPREL16        36
++#define R_SW64_GOTTPREL        37
++#define R_SW64_TPREL64         38
++#define R_SW64_TPRELHI         39
++#define R_SW64_TPRELLO         40
++#define R_SW64_TPREL16         41
++#define R_SW64_LITERAL_GOT     43
++
+ /* LoongArch relocations */
+ #define R_LARCH_NONE			      0
+ #define R_LARCH_64			      2
+diff --git a/util/grub-mkimagexx.c b/util/grub-mkimagexx.c
+index e50b295..d50a178 100644
+--- a/util/grub-mkimagexx.c
++++ b/util/grub-mkimagexx.c
+@@ -782,8 +782,14 @@ SUFFIX (relocate_addrs) (Elf_Ehdr *e, struct section_metadata *smd,
+   Elf_Half i;
+   Elf_Shdr *s;
+ #ifdef MKIMAGE_ELF64
++  grub_uint64_t got_offset = 0;
++
+   struct grub_ia64_trampoline *tr = (void *) (pe_target + tramp_off);
+   grub_uint64_t *gpptr = (void *) (pe_target + got_off);
++  if (image_target->elf_target == EM_SW_64) {
++    got_offset = got_off;
++    gpptr = (void *) (pe_target + got_offset + 0x8000);
++  }
+   unsigned unmatched_adr_got_page = 0;
+   struct grub_loongarch64_stack stack;
+   grub_loongarch64_stack_init (&stack);
+@@ -1126,6 +1132,119 @@ SUFFIX (relocate_addrs) (Elf_Ehdr *e, struct section_metadata *smd,
+ 		   }
+ 	       break;
+ 	       }
++             case EM_SW_64:
++              {
++               sym_addr += addend;
++               switch (ELF_R_TYPE (info))
++                 {
++                 case R_SW64_NONE:
++                   break;
++                 case R_SW64_REFLONG:
++                   *(grub_uint32_t *)target = grub_host_to_target32 (sym_addr);
++                   break;
++                 case R_SW64_REFQUAD:
++                   {
++                     *(grub_uint32_t *)target = grub_host_to_target32(sym_addr);
++                     *((grub_uint32_t *)target + 1) = grub_host_to_target32(sym_addr >> 32);
++                     break;
++                   }
++                 case R_SW64_GPREL32:
++                   {
++                     *(grub_uint32_t *) target = (grub_host_to_target64 (sym_addr) -
++                                     ((char *) gpptr - (char *)pe_target + image_target->vaddr_offset )) & 0xffffffff;
++                     break;
++                   }
++                 case R_SW64_LITERAL:
++                   {
++                     grub_uint64_t li_hi;
++                     grub_uint64_t li_lo;
++
++                     li_hi = (grub_uint64_t)pe_target + got_offset + (((grub_uint64_t)ELF_R_TYPE(r->r_info)) >> 8 );
++                     li_lo = li_hi - ((grub_uint64_t) gpptr);
++                     *(grub_uint16_t *) target = (li_lo & 0xffff);
++                     *(grub_uint64_t *) (li_hi) = grub_host_to_target64(grub_host_to_target64 (sym_addr));
++                     got_offset += 8;
++                     break;
++                   }
++                 case R_SW64_LITERAL_GOT:
++                   break;
++                 case R_SW64_LITUSE:
++                   break;
++                 case R_SW64_GPDISP:
++                   {
++                     grub_uint64_t hi;
++                     grub_uint64_t lo;
++                     grub_int64_t gpoffset = (((char *) gpptr - (char *) pe_target + image_target->vaddr_offset))
++                             - ((offset + target_section_addr + image_target->vaddr_offset));
++                     if (gpoffset & 0x8000) {
++                             hi = ((gpoffset + 0x8000) >> 16) & 0xffff;
++                             lo = gpoffset & 0xffff;
++                     } else {
++                             hi = (gpoffset >> 16) & 0xffff;
++                             lo = gpoffset & 0xffff;
++                     }
++                     *(grub_uint32_t *) target = grub_host_to_target32 ((grub_target_to_host32 (*target) & 0xffff0000) | (hi & 0xffff));
++                     *(grub_uint32_t *) ((unsigned long)target + addend) =
++                             grub_host_to_target32 ((grub_target_to_host32 (*(grub_uint32_t *)
++                                                             ((unsigned long)target + addend)) & 0xffff0000) | (lo & 0xffff));
++                     break;
++
++                   }
++                 case R_SW64_BRADDR:
++                   {
++                     grub_uint64_t braddr = grub_host_to_target64 (grub_target_to_host64 (*target) + sym_addr) - ((grub_uint64_t)target + 4);
++                     braddr = braddr >> 2;
++                     *(grub_uint32_t *) target = (*(grub_uint32_t *)target & (~0x1fffff)) | (braddr & 0x1fffff);
++                     break;
++                   }
++                 case R_SW64_HINT:
++                   break;
++                 case R_SW64_SREL32:
++                   {
++                     grub_uint64_t srel32 = grub_host_to_target64 (grub_target_to_host64 (*target) + sym_addr);
++                     srel32 -= (grub_uint64_t)target;
++                     *(grub_uint32_t *) target = srel32;
++                     break;
++                   }
++                 case R_SW64_SREL64:
++                   {
++                     grub_uint64_t srel64 = grub_host_to_target64 (grub_target_to_host64 (*target) + sym_addr);
++                     srel64 -= (grub_uint64_t)target;
++                     *(grub_uint64_t *) target = srel64;
++                     break;
++                   }
++                 case R_SW64_GPRELHIGH:
++                   {
++                     grub_uint64_t gprel_hi = ((grub_host_to_target64 (sym_addr) - (((char *) gpptr - (char *)pe_target + image_target->vaddr_offset) + 0x0)));
++
++                     if (gprel_hi & 0x8000)
++                             gprel_hi = ((gprel_hi + 0x8000) >> 16) & 0xffff;
++                     else
++                             gprel_hi = (gprel_hi >> 16) & 0xffff;
++
++                     *(grub_uint32_t *) target = grub_host_to_target32 ((grub_target_to_host32 (*target) & 0xffff0000) | (gprel_hi & 0xffff));
++                     break;
++                   }
++                 case R_SW64_GPRELLOW:
++                   {
++                     grub_uint64_t gprel_lo = (grub_host_to_target64 (sym_addr) - ((char *) gpptr - (char *)pe_target + image_target->vaddr_offset));
++                     *(grub_uint32_t *) target = grub_host_to_target32 ((grub_target_to_host32 (*target) & 0xffff0000) | (gprel_lo & 0xffff));
++                     break;
++                   }
++                 case R_SW64_GPREL16:
++                   {
++                     grub_uint64_t gprel16 = grub_host_to_target64 (grub_target_to_host64 (*target) + sym_addr);
++                     gprel16 = (grub_uint64_t)(gprel16 - (grub_uint64_t)gpptr);
++                     *(grub_uint16_t *) target = gprel16;
++                     break;
++                   }
++                 default:
++                   grub_util_error (_("relocation 0x%lx is not implemented yet"),
++                                   ELF_R_TYPE (info));
++                   break;
++                 }
++               break;
++              }
+ 	     case EM_LOONGARCH:
+ 	       {
+ 		 grub_int64_t pc;
+@@ -1663,6 +1782,19 @@ translate_relocation_pe (struct translate_context *ctx,
+ 			       image_target);
+ 	}
+       break;
++    case EM_SW_64:
++      if (ELF_R_TYPE (info) == R_SW64_REFQUAD)
++        {
++         grub_util_info ("adding a relocation entry for 0x%llx",
++                         (unsigned long long) addr);
++         ctx->current_address
++           = add_fixup_entry (&ctx->lst,
++                              GRUB_PE32_REL_BASED_DIR64,
++                              addr,
++                              0, ctx->current_address,
++                              image_target);
++       }
++      break;
+     case EM_IA_64:
+       switch (ELF_R_TYPE (info))
+ 	{
+@@ -2144,7 +2276,7 @@ make_reloc_section (Elf_Ehdr *e, struct grub_mkimage_layout *layout,
+ 		       + image_target->vaddr_offset,
+ 		       2 * layout->ia64jmpnum,
+ 		       image_target);
+-  if (image_target->elf_target == EM_IA_64 || image_target->elf_target == EM_AARCH64)
++  if (image_target->elf_target == EM_IA_64 || image_target->elf_target == EM_AARCH64 || image_target->elf_target == EM_SW_64)
+     create_u64_fixups (&ctx,
+ 		       layout->got_off
+ 		       + image_target->vaddr_offset,
+@@ -2516,6 +2648,17 @@ SUFFIX (grub_mkimage_load_image) (const char *kernel_path,
+ 	  layout->got_off = layout->kernel_size;
+ 	  layout->kernel_size += ALIGN_UP (layout->got_size, 16);
+ 	}
++      else if (image_target->elf_target == EM_SW_64)
++        {
++          grub_size_t tramp;
++
++          layout->kernel_size = ALIGN_UP (layout->kernel_size, 16);
++
++          grub_sw64_dl_get_tramp_got_size (e, &tramp, &layout->got_size);
++
++          layout->got_off = layout->kernel_size;
++          layout->kernel_size += ALIGN_UP (layout->got_size, 16);
++        }
+ #endif
+ 
+       if (image_target->id == IMAGE_EFI)
+diff --git a/util/grub-module-verifier.c b/util/grub-module-verifier.c
+index 91d9e8f..9d41c8b 100644
+--- a/util/grub-module-verifier.c
++++ b/util/grub-module-verifier.c
+@@ -209,6 +209,26 @@ struct grub_module_verifier_arch archs[] = {
+       -1
+     }
+   },
++  { "sw64", 8, 0, EM_SW_64, GRUB_MODULE_VERIFY_SUPPORTS_REL | GRUB_MODULE_VERIFY_SUPPORTS_RELA, (int[]){
++      R_SW64_NONE,
++      R_SW64_REFLONG,
++      R_SW64_REFQUAD,
++      R_SW64_GPREL32,
++      R_SW64_LITERAL,
++      R_SW64_LITERAL_GOT,
++      R_SW64_LITUSE,
++      R_SW64_GPDISP,
++      R_SW64_BRSGP,
++      R_SW64_BRADDR,
++      R_SW64_HINT,
++      R_SW64_SREL32,
++      R_SW64_SREL64,
++      R_SW64_GPRELHIGH,
++      R_SW64_GPRELLOW,
++      R_SW64_GPREL16,
++      -1
++    }
++  },
+ };
+ 
+ struct platform_whitelist {
+-- 
+2.20.1
+

--- a/debian/patches/sw64/0003-sw64-Add-awareness-for-SW64-reloations.patch
+++ b/debian/patches/sw64/0003-sw64-Add-awareness-for-SW64-reloations.patch
@@ -244,14 +244,14 @@ index cd1f46c..f316ab7 100644
  grub_arm64_dl_get_tramp_got_size (const void *ehdr, grub_size_t *tramp,
  				  grub_size_t *got);
  
-+#if defined (__sw_64__)
++
 +#define GRUB_SW64_DL_TRAMP_ALIGN 16
 +#define GRUB_SW64_DL_GOT_ALIGN 16
 +
 +grub_err_t
 +grub_sw64_dl_get_tramp_got_size (const void *ehdr, grub_size_t *tramp,
 +                                grub_size_t *got);
-+#endif
++
 +
  #if defined (__ia64__)
  #define GRUB_ARCH_DL_TRAMP_ALIGN GRUB_IA64_DL_TRAMP_ALIGN

--- a/debian/patches/sw64/0004-sw64-Add-auxiliary-files.patch
+++ b/debian/patches/sw64/0004-sw64-Add-auxiliary-files.patch
@@ -1,0 +1,1749 @@
+From 3786978bd9163ec71dea71c567a68c14fed4dadd Mon Sep 17 00:00:00 2001
+From: sunway_fw <sunway_fw@wxiat.com>
+Date: Thu, 14 May 2026 11:41:58 +0800
+Subject: [PATCH] sw64: Add auxiliary files
+
+To support a new architecture we need to provide a few helper functions
+for memory, cache, timer, etc support.
+
+Signed-off-by: sunway_fw <sunway_fw@wxiat.com>
+---
+ grub-core/kern/efi/mm.c            |   2 +-
+ grub-core/kern/sw64/cache.c        |  63 +++
+ grub-core/kern/sw64/cache_flush.S  |  44 ++
+ grub-core/kern/sw64/dl_helper.c    |  71 +++
+ grub-core/kern/sw64/efi/callwrap.S | 261 +++++++++++
+ grub-core/kern/sw64/efi/init.c     |  85 ++++
+ grub-core/lib/sw64/divide.S        | 677 +++++++++++++++++++++++++++++
+ grub-core/lib/sw64/setjmp.S        |  75 ++++
+ include/grub/efi/efi.h             |   2 +-
+ include/grub/sw64/divide.h         |  11 +
+ include/grub/sw64/efi/memory.h     |   7 +
+ include/grub/sw64/efi/time.h       |  23 +
+ include/grub/sw64/io.h             |  62 +++
+ include/grub/sw64/jmpbuf-offsets.h |  35 ++
+ include/grub/sw64/kernel.h         |  25 ++
+ include/grub/sw64/regdef.h         |  44 ++
+ include/grub/sw64/setjmp.h         |  27 ++
+ include/grub/sw64/time.h           |  28 ++
+ include/grub/sw64/types.h          |  32 ++
+ 19 files changed, 1572 insertions(+), 2 deletions(-)
+ create mode 100644 grub-core/kern/sw64/cache.c
+ create mode 100644 grub-core/kern/sw64/cache_flush.S
+ create mode 100644 grub-core/kern/sw64/dl_helper.c
+ create mode 100644 grub-core/kern/sw64/efi/callwrap.S
+ create mode 100644 grub-core/kern/sw64/efi/init.c
+ create mode 100644 grub-core/lib/sw64/divide.S
+ create mode 100644 grub-core/lib/sw64/setjmp.S
+ create mode 100644 include/grub/sw64/divide.h
+ create mode 100644 include/grub/sw64/efi/memory.h
+ create mode 100644 include/grub/sw64/efi/time.h
+ create mode 100644 include/grub/sw64/io.h
+ create mode 100644 include/grub/sw64/jmpbuf-offsets.h
+ create mode 100644 include/grub/sw64/kernel.h
+ create mode 100644 include/grub/sw64/regdef.h
+ create mode 100644 include/grub/sw64/setjmp.h
+ create mode 100644 include/grub/sw64/time.h
+ create mode 100644 include/grub/sw64/types.h
+
+diff --git a/grub-core/kern/efi/mm.c b/grub-core/kern/efi/mm.c
+index 6a6fba8..98578f9 100644
+--- a/grub-core/kern/efi/mm.c
++++ b/grub-core/kern/efi/mm.c
+@@ -657,7 +657,7 @@ grub_efi_mm_init (void)
+ }
+ 
+ #if defined (__aarch64__) || defined (__arm__) || defined (__riscv) || \
+-  defined (__loongarch__)
++  defined (__loongarch__) || defined (__sw_64__)
+ grub_err_t
+ grub_efi_get_ram_base(grub_addr_t *base_addr)
+ {
+diff --git a/grub-core/kern/sw64/cache.c b/grub-core/kern/sw64/cache.c
+new file mode 100644
+index 0000000..2c19b8b
+--- /dev/null
++++ b/grub-core/kern/sw64/cache.c
+@@ -0,0 +1,63 @@
++/*
++ *  GRUB  --  GRand Unified Bootloader
++ *  Copyright (C) 2026  Free Software Foundation, Inc.
++ *
++ *  GRUB is free software: you can redistribute it and/or modify
++ *  it under the terms of the GNU General Public License as published by
++ *  the Free Software Foundation, either version 3 of the License, or
++ *  (at your option) any later version.
++ *
++ *  GRUB is distributed in the hope that it will be useful,
++ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *  GNU General Public License for more details.
++ *
++ *  You should have received a copy of the GNU General Public License
++ *  along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++#include <grub/cache.h>
++#include <grub/misc.h>
++
++static grub_int64_t dlinesz;
++static grub_int64_t ilinesz;
++
++/* Prototypes for asm functions. */
++void grub_arch_clean_dcache_range (grub_addr_t beg, grub_addr_t end,
++				   grub_size_t line_size);
++void grub_arch_invalidate_icache_range (grub_addr_t beg, grub_addr_t end,
++					grub_size_t line_size);
++
++static void
++probe_caches (void)
++{
++  /* TODO */
++  dlinesz = 128;
++  ilinesz = 128;
++}
++
++void
++grub_arch_sync_caches (void *address, grub_size_t len)
++{
++  grub_size_t start, end, max_align;
++
++  if (dlinesz == 0)
++    probe_caches();
++  if (dlinesz == 0)
++    grub_fatal ("Unknown cache line size!");
++
++  max_align = dlinesz > ilinesz ? dlinesz : ilinesz;
++
++  start = ALIGN_DOWN ((grub_size_t) address, max_align);
++  end = ALIGN_UP ((grub_size_t) address + len, max_align);
++
++  grub_arch_clean_dcache_range (start, end, dlinesz);
++  grub_arch_invalidate_icache_range (start, end, ilinesz);
++}
++
++void
++grub_arch_sync_dma_caches (volatile void *address __attribute__((unused)),
++			   grub_size_t len __attribute__((unused)))
++{
++  /* DMA incoherent devices not supported yet */
++}
+diff --git a/grub-core/kern/sw64/cache_flush.S b/grub-core/kern/sw64/cache_flush.S
+new file mode 100644
+index 0000000..b26a003
+--- /dev/null
++++ b/grub-core/kern/sw64/cache_flush.S
+@@ -0,0 +1,44 @@
++/*
++ *  GRUB  --  GRand Unified Bootloader
++ *  Copyright (C) 2026  Free Software Foundation, Inc.
++ *
++ *  GRUB is free software: you can redistribute it and/or modify
++ *  it under the terms of the GNU General Public License as published by
++ *  the Free Software Foundation, either version 3 of the License, or
++ *  (at your option) any later version.
++ *
++ *  GRUB is distributed in the hope that it will be useful,
++ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *  GNU General Public License for more details.
++ *
++ *  You should have received a copy of the GNU General Public License
++ *  along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++#include <grub/symbol.h>
++
++	.file	"cache_flush.S"
++	.text
++
++/*
++ * Simple cache maintenance functions
++ */
++
++/*
++ * a0 - *beg (inclusive)
++ * a1 - *end (exclusive)
++ * a2 - line size
++*/
++FUNCTION(grub_arch_clean_dcache_range)
++	/* TODO */
++	ret
++
++/*
++ * a0 - *beg (inclusive)
++ * a1 - *end (exclusive)
++ * a2 - line size
++ */
++FUNCTION(grub_arch_invalidate_icache_range)
++	memb
++	ret
+diff --git a/grub-core/kern/sw64/dl_helper.c b/grub-core/kern/sw64/dl_helper.c
+new file mode 100644
+index 0000000..856978f
+--- /dev/null
++++ b/grub-core/kern/sw64/dl_helper.c
+@@ -0,0 +1,71 @@
++/* dl.c - arch-dependent part of loadable module support */
++/*
++ *  GRUB  --  GRand Unified Bootloader
++ *  Copyright (C) 2002,2004,2005,2007,2009,2026  Free Software Foundation, Inc.
++ *
++ *  GRUB is free software: you can redistribute it and/or modify
++ *  it under the terms of the GNU General Public License as published by
++ *  the Free Software Foundation, either version 3 of the License, or
++ *  (at your option) any later version.
++ *
++ *  GRUB is distributed in the hope that it will be useful,
++ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *  GNU General Public License for more details.
++ *
++ *  You should have received a copy of the GNU General Public License
++ *  along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++#include <grub/dl.h>
++#include <grub/elf.h>
++#include <grub/misc.h>
++#include <grub/err.h>
++#include <grub/mm.h>
++
++#pragma GCC diagnostic ignored "-Wcast-align"
++
++grub_err_t
++grub_sw64_dl_get_tramp_got_size (const void *ehdr, grub_size_t *tramp,
++				 grub_size_t *got)
++{
++  const Elf64_Ehdr *e = ehdr;
++  grub_size_t cntt = 0, cntg = 0;
++  const Elf64_Shdr *s;
++  unsigned i;
++
++  *tramp = 0;
++  *got = 0;
++
++  /* Find a symbol table.  */
++  for (i = 0, s = (Elf64_Shdr *) ((char *) e + grub_le_to_cpu32 (e->e_shoff));
++       i < grub_le_to_cpu16 (e->e_shnum);
++       i++, s = (Elf64_Shdr *) ((char *) s + grub_le_to_cpu16 (e->e_shentsize)))
++    if (grub_le_to_cpu32 (s->sh_type) == SHT_SYMTAB)
++      break;
++
++  if (i == grub_le_to_cpu16 (e->e_shnum))
++    return GRUB_ERR_NONE;
++
++  for (i = 0, s = (Elf64_Shdr *) ((char *) e + grub_le_to_cpu32 (e->e_shoff));
++       i < grub_le_to_cpu16 (e->e_shnum);
++       i++, s = (Elf64_Shdr *) ((char *) s + grub_le_to_cpu16 (e->e_shentsize)))
++    if (grub_le_to_cpu32 (s->sh_type) == SHT_RELA)
++      {
++	Elf64_Rela *rel, *max;
++
++	for (rel = (Elf64_Rela *) ((char *) e + grub_le_to_cpu32 (s->sh_offset)),
++	       max = rel + grub_le_to_cpu32 (s->sh_size) / grub_le_to_cpu16 (s->sh_entsize);
++	     rel < max; rel++)
++	  switch (ELF64_R_TYPE (grub_le_to_cpu32 (rel->r_info)))
++	    {
++	    case R_SW64_LITERAL:
++	      cntg++;
++	      break;
++	    }
++      }
++  *tramp = cntt;
++  *got = cntg * sizeof (grub_uint64_t);
++
++  return GRUB_ERR_NONE;
++}
+diff --git a/grub-core/kern/sw64/efi/callwrap.S b/grub-core/kern/sw64/efi/callwrap.S
+new file mode 100644
+index 0000000..13ee13d
+--- /dev/null
++++ b/grub-core/kern/sw64/efi/callwrap.S
+@@ -0,0 +1,261 @@
++	.file   "callwrap.S"
++	.text
++	.align 4
++	.globl  sw_efi_wrap_0
++	.globl  sw_efi_wrap_1
++	.globl  sw_efi_wrap_2
++	.globl  sw_efi_wrap_3
++	.globl  sw_efi_wrap_4
++	.globl  sw_efi_wrap_5
++	.globl  sw_efi_wrap_6
++	.globl  sw_efi_wrap_7
++	.globl  sw_efi_wrap_10
++
++	.ent sw_efi_wrap_0
++sw_efi_wrap_0:
++
++	ldi $30,-32($30)
++	stl $26,0($30)
++	stl $15,8($30)
++	mov $30,$15
++	.prologue 1
++	stl $16,16($15)
++	ldl $27,16($15)
++	call $26,($27),0
++	#ldi $29,0($29)          !gpdisp!29
++	mov $15,$30
++	ldl $26,0($30)
++	ldl $15,8($30)
++	ldi $30,32($30)
++	ret $31,($26),1
++
++	.end sw_efi_wrap_0
++
++	.ent sw_efi_wrap_1
++sw_efi_wrap_1:
++
++	ldi $30,-32($30)
++        stl $26,0($30)
++        stl $15,8($30)
++        mov $30,$15
++        .prologue 1
++        stl $16,16($15)
++        stl $17,24($15)
++        ldl $27,16($15)
++        ldl $16,24($15)
++        call $26,($27),0
++       #ldih $29,0($26)         !gpdisp!31
++       #ldi $29,0($29)          !gpdisp!31
++        mov $15,$30
++        ldl $26,0($30)
++        ldl $15,8($30)
++        ldi $30,32($30)
++        ret $31,($26),1
++	.end sw_efi_wrap_1
++
++	.ent sw_efi_wrap_2
++sw_efi_wrap_2:
++	ldi $30,-48($30)
++        stl $26,0($30)
++        stl $15,8($30)
++        mov $30,$15
++        .prologue 1
++        stl $16,16($15)
++        stl $17,24($15)
++        stl $18,32($15)
++        ldl $27,16($15)
++        ldl $16,24($15)
++        ldl $17,32($15)
++        call $26,($27),0
++        #ldih $29,0($26)         !gpdisp!33
++        #ldi $29,0($29)          !gpdisp!33
++        mov $15,$30
++        ldl $26,0($30)
++        ldl $15,8($30)
++        ldi $30,48($30)
++        ret $31,($26),1
++	.end sw_efi_wrap_2
++
++	.ent sw_efi_wrap_3
++sw_efi_wrap_3:
++	ldi $30,-48($30)
++        stl $26,0($30)
++        stl $15,8($30)
++        mov $30,$15
++        .prologue 1
++        stl $16,16($15)
++        stl $17,24($15)
++        stl $18,32($15)
++        stl $19,40($15)
++        ldl $27,16($15)
++        ldl $16,24($15)
++        ldl $17,32($15)
++        ldl $18,40($15)
++        call $26,($27),0
++        #ldih $29,0($26)         !gpdisp!35
++        #ldi $29,0($29)          !gpdisp!35
++        mov $15,$30
++        ldl $26,0($30)
++        ldl $15,8($30)
++        ldi $30,48($30)
++        ret $31,($26),1
++	.end sw_efi_wrap_3
++
++	.ent sw_efi_wrap_4
++sw_efi_wrap_4:
++	ldi $30,-64($30)
++        stl $26,0($30)
++        stl $15,8($30)
++        mov $30,$15
++        .prologue 1
++        stl $16,16($15)
++        stl $17,24($15)
++        stl $18,32($15)
++        stl $19,40($15)
++        stl $20,48($15)
++        ldl $27,16($15)
++        ldl $16,24($15)
++        ldl $17,32($15)
++        ldl $18,40($15)
++        ldl $19,48($15)
++        call $26,($27),0
++        #ldih $29,0($26)         !gpdisp!37
++        #ldi $29,0($29)          !gpdisp!37
++        mov $15,$30
++        ldl $26,0($30)
++        ldl $15,8($30)
++        ldi $30,64($30)
++        ret $31,($26),1
++	.end sw_efi_wrap_4
++
++	.ent sw_efi_wrap_5
++sw_efi_wrap_5:
++	ldi $30,-64($30)
++        stl $26,0($30)
++        stl $15,8($30)
++        mov $30,$15
++        .prologue 1
++        stl $16,16($15)
++        stl $17,24($15)
++        stl $18,32($15)
++        stl $19,40($15)
++        stl $20,48($15)
++        stl $21,56($15)
++        ldl $27,16($15)
++        ldl $16,24($15)
++        ldl $17,32($15)
++        ldl $18,40($15)
++        ldl $19,48($15)
++        ldl $20,56($15)
++        call $26,($27),0
++        #ldih $29,0($26)         !gpdisp!39
++        #ldi $29,0($29)          !gpdisp!39
++        mov $15,$30
++        ldl $26,0($30)
++        ldl $15,8($30)
++        ldi $30,64($30)
++        ret $31,($26),1
++	.end sw_efi_wrap_5
++
++
++	.ent sw_efi_wrap_6
++sw_efi_wrap_6:
++	ldi $30,-64($30)
++        stl $26,0($30)
++        stl $15,8($30)
++        mov $30,$15
++        .prologue 1
++        stl $16,16($15)
++        stl $17,24($15)
++        stl $18,32($15)
++        stl $19,40($15)
++        stl $20,48($15)
++        stl $21,56($15)
++        ldl $27,16($15)
++        ldl $16,24($15)
++        ldl $17,32($15)
++        ldl $18,40($15)
++        ldl $19,48($15)
++        ldl $20,56($15)
++        ldl $21,64($15)
++        call $26,($27),0
++        #ldih $29,0($26)         !gpdisp!41
++        #ldi $29,0($29)          !gpdisp!41
++        mov $15,$30
++        ldl $26,0($30)
++        ldl $15,8($30)
++        ldi $30,64($30)
++        ret $31,($26),1
++	.end sw_efi_wrap_6
++
++	.ent sw_efi_wrap_7
++sw_efi_wrap_7:
++	ldi $30,-80($30)
++        stl $26,16($30)
++        stl $15,24($30)
++        mov $30,$15
++        .prologue 1
++        stl $16,32($15)
++        stl $17,40($15)
++        stl $18,48($15)
++        stl $19,56($15)
++        stl $20,64($15)
++        stl $21,72($15)
++        ldl $1,88($15)
++        stl $1,0($30)
++        ldl $27,32($15)
++        ldl $16,40($15)
++        ldl $17,48($15)
++        ldl $18,56($15)
++        ldl $19,64($15)
++        ldl $20,72($15)
++        ldl $21,80($15)
++        call $26,($27),0
++        #ldih $29,0($26)         !gpdisp!43
++        #ldi $29,0($29)          !gpdisp!43
++        mov $15,$30
++        ldl $26,16($30)
++        ldl $15,24($30)
++        ldi $30,80($30)
++        ret $31,($26),1
++	.end sw_efi_wrap_7
++
++
++	.ent sw_efi_wrap_10
++sw_efi_wrap_10:
++	ldi $30,-96($30)
++        stl $26,32($30)
++        stl $15,40($30)
++        mov $30,$15
++        .prologue 1
++        stl $16,48($15)
++        stl $17,56($15)
++        stl $18,64($15)
++        stl $19,72($15)
++        stl $20,80($15)
++        stl $21,88($15)
++        ldl $1,104($15)
++        stl $1,0($30)
++        ldl $1,112($15)
++        stl $1,8($30)
++        ldl $1,120($15)
++        stl $1,16($30)
++        ldl $1,128($15)
++        stl $1,24($30)
++        ldl $27,48($15)
++        ldl $16,56($15)
++        ldl $17,64($15)
++        ldl $18,72($15)
++        ldl $19,80($15)
++        ldl $20,88($15)
++        ldl $21,96($15)
++        call $26,($27),0
++        #ldih $29,0($26)         !gpdisp!45
++        #ldi $29,0($29)          !gpdisp!45
++        mov $15,$30
++        ldl $26,32($30)
++        ldl $15,40($30)
++        ldi $30,96($30)
++        ret $31,($26),1
++
++	.end sw_efi_wrap_10
+diff --git a/grub-core/kern/sw64/efi/init.c b/grub-core/kern/sw64/efi/init.c
+new file mode 100644
+index 0000000..be55947
+--- /dev/null
++++ b/grub-core/kern/sw64/efi/init.c
+@@ -0,0 +1,85 @@
++/* init.c - initialize a sw64-based EFI system */
++/*
++ *  GRUB  --  GRand Unified Bootloader
++ *  Copyright (C) 2026 Free Software Foundation, Inc.
++ *
++ *  GRUB is free software: you can redistribute it and/or modify
++ *  it under the terms of the GNU General Public License as published by
++ *  the Free Software Foundation, either version 3 of the License, or
++ *  (at your option) any later version.
++ *
++ *  GRUB is distributed in the hope that it will be useful,
++ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *  GNU General Public License for more details.
++ *
++ *  You should have received a copy of the GNU General Public License
++ *  along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++#include <grub/env.h>
++#include <grub/kernel.h>
++#include <grub/misc.h>
++#include <grub/mm.h>
++#include <grub/time.h>
++#include <grub/efi/efi.h>
++#include <grub/loader.h>
++
++static grub_uint64_t tmr;
++static grub_efi_event_t tmr_evt;
++
++static grub_uint64_t
++grub_efi_get_time_ms (void)
++{
++  return tmr;
++}
++
++static void
++increment_timer (grub_efi_event_t event __attribute__ ((unused)),
++                 void *context __attribute__ ((unused)))
++{
++  tmr += 10;
++}
++
++static void
++grub_print_info (void)
++{
++  grub_printf ("GNU %s %s\n", PACKAGE_NAME, PACKAGE_VERSION);
++  grub_printf ("Build Time: %s %s\n", __DATE__, __TIME__);
++}
++
++void
++grub_machine_init (void)
++{
++  grub_efi_boot_services_t *b;
++
++  grub_efi_init ();
++
++  b = grub_efi_system_table->boot_services;
++
++  efi_call_5 (b->create_event, GRUB_EFI_EVT_TIMER | GRUB_EFI_EVT_NOTIFY_SIGNAL,
++	      GRUB_EFI_TPL_CALLBACK, increment_timer, NULL, &tmr_evt);
++  efi_call_3 (b->set_timer, tmr_evt, GRUB_EFI_TIMER_PERIODIC, 100000);
++
++  grub_print_info ();
++  grub_install_get_time_ms (grub_efi_get_time_ms);
++}
++
++void
++grub_machine_fini (int flags)
++{
++  grub_efi_boot_services_t *b;
++
++  if (!(flags & GRUB_LOADER_FLAG_NORETURN))
++    return;
++
++  b = grub_efi_system_table->boot_services;
++
++  efi_call_3 (b->set_timer, tmr_evt, GRUB_EFI_TIMER_CANCEL, 0);
++  efi_call_1 (b->close_event, tmr_evt);
++
++  grub_efi_fini ();
++
++  if (!(flags & GRUB_LOADER_FLAG_EFI_KEEP_ALLOCATED_MEMORY))
++    grub_efi_memory_fini ();
++}
+diff --git a/grub-core/lib/sw64/divide.S b/grub-core/lib/sw64/divide.S
+new file mode 100644
+index 0000000..980aba6
+--- /dev/null
++++ b/grub-core/lib/sw64/divide.S
+@@ -0,0 +1,677 @@
++/*
++ * divide.S
++ *
++ * (C) 1995 Linus Torvalds
++ *
++ * Alpha division..
++ */
++
++/*
++ * The alpha chip doesn't provide hardware division, so we have to do it
++ * by hand.  The compiler expects the functions
++ *
++ *	__divqu: 64-bit unsigned long divide
++ *	__remqu: 64-bit unsigned long remainder
++ *	__divqs/__remqs: signed 64-bit
++ *	__divlu/__remlu: unsigned 32-bit
++ *	__divls/__remls: signed 32-bit
++ *
++ * These are not normal C functions: instead of the normal
++ * calling sequence, these expect their arguments in registers
++ * $24 and $25, and return the result in $27. Register $28 may
++ * be clobbered (assemembly temporary), anything else must be saved.
++ *
++ * In short: painful.
++ *
++ * This is a rather simple bit-at-a-time algorithm: it's very good
++ * at dividing random 64-bit numembers, but the more usual case where
++ * the divisor is small is handled better by the DEC algorithm
++ * using lookup tables. This uses much less memory, though, and is
++ * nicer on the cache.. Besides, I don't know the copyright status
++ * of the DEC code.
++ */
++
++/*
++ * My temporaries:
++ *	$0 - current bit
++ *	$1 - shifted divisor
++ *	$2 - modulus/quotient
++ *
++ *	$23 - return address
++ *	$24 - dividend
++ *	$25 - divisor
++ *
++ *	$27 - quotient/modulus
++ *	$28 - compare status
++ */
++
++#define halt .long 0
++
++/*
++ * Select function type and registers
++ */
++#define mask	$0
++#define divisor	$1
++#define compare $28
++#define tmp1	$3
++#define tmp2	$4
++
++#define DIV
++#define INTSIZE
++
++#undef DIV_ONLY
++#undef MOD_ONLY
++#undef func
++#undef modulus
++#undef quotient
++#undef GETSIGN
++#undef STACK
++#undef ufunction
++#undef sfunction
++#undef LONGIFY
++#undef SLONGIFY
++
++#ifdef DIV
++#define DIV_ONLY(x,y...) x,##y
++#define MOD_ONLY(x,y...)
++#define func(x) __div##x
++#define modulus $2
++#define quotient $27
++#define GETSIGN(x) xor $24,$25,x
++#define STACK 48
++#else
++#define DIV_ONLY(x,y...)
++#define MOD_ONLY(x,y...) x,##y
++#define func(x) __rem##x
++#define modulus $27
++#define quotient $2
++#define GETSIGN(x) bis $24,$24,x
++#define STACK 32
++#endif
++
++/*
++ * For 32-bit operations, we need to extend to 64-bit
++ */
++#ifdef INTSIZE
++#define ufunction func(wu)
++#define sfunction func(w)
++#define LONGIFY(x) zapnot x,15,x
++/* define SLONGIFY(x) addw x,0,x */
++#define SLONGIFY(x)
++#else
++#define ufunction func(lu)
++#define sfunction func(l)
++#define LONGIFY(x)
++#define SLONGIFY(x)
++#endif
++
++.set noat
++.align	3
++.globl	ufunction
++.ent	ufunction
++ufunction:
++	subl	$30,STACK,$30
++	.frame	$30,STACK,$23
++	.prologue 0
++
++7:	stl	$1, 0($30)
++	bis	$25,$25,divisor
++	stl	$2, 8($30)
++	bis	$24,$24,modulus
++	stl	$0,16($30)
++	bis	$31,$31,quotient
++	LONGIFY(divisor)
++	stl	tmp1,24($30)
++	LONGIFY(modulus)
++	bis	$31,1,mask
++	DIV_ONLY(stl tmp2,32($30))
++	beq	divisor, 9f			/* div by zero */
++
++#ifdef INTSIZE
++	/*
++	 * shift divisor left, using 3-bit shifts for
++	 * 32-bit divides as we can't overflow. Three-bit
++	 * shifts will result in looping three times less
++	 * here, but can result in two loops more later.
++	 * Thus using a large shift isn't worth it (and
++	 * s8add pairs better than a sll..)
++	 */
++1:	cmpult	divisor,modulus,compare
++	s8addl	divisor,$31,divisor
++	s8addl	mask,$31,mask
++	bne	compare,1b
++#else
++1:	cmpult	divisor,modulus,compare
++	blt     divisor, 2f
++	addl	divisor,divisor,divisor
++	addl	mask,mask,mask
++	bne	compare,1b
++	nop
++#endif
++
++	/* ok, start to go right again.. */
++2:	DIV_ONLY(addl quotient,mask,tmp2)
++	srl	mask,1,mask
++	cmpule	divisor,modulus,compare
++	subl	modulus,divisor,tmp1
++	DIV_ONLY(selne compare,tmp2,quotient,quotient)
++	srl	divisor,1,divisor
++	selne	compare,tmp1,modulus,modulus
++	bne	mask,2b
++
++9:	ldl	$1, 0($30)
++	ldl	$2, 8($30)
++	ldl	$0,16($30)
++	ldl	tmp1,24($30)
++	DIV_ONLY(ldl tmp2,32($30))
++	addl	$30,STACK,$30
++	ret	$31,($23),1
++	.end	ufunction
++
++/*
++ * Uhh.. Ugly signed division. I'd rather not have it at all, but
++ * it's needed in some circumstances. There are different ways to
++ * handle this, really. This does:
++ * 	-a / b = a / -b = -(a / b)
++ *	-a % b = -(a % b)
++ *	a % -b = a % b
++ * which is probably not the best solution, but at least should
++ * have the property that (x/y)*y + (x%y) = x.
++ */
++.align 3
++.globl	sfunction
++.ent	sfunction
++sfunction:
++	subl	$30,STACK,$30
++	.frame	$30,STACK,$23
++	.prologue 0
++	bis	$24,$25,$28
++	SLONGIFY($28)
++	bge	$28,7b
++	stl	$24,0($30)
++	subl	$31,$24,$28
++	stl	$25,8($30)
++	sellt	$24,$28,$24,$24	/* abs($24) */
++	stl	$23,16($30)
++	subl	$31,$25,$28
++	stl	tmp1,24($30)
++	sellt	$25,$28,$25,$25	/* abs($25) */
++	nop
++	bsr	$23,ufunction
++	ldl	$24,0($30)
++	ldl	$25,8($30)
++	GETSIGN($28)
++	subl	$31,$27,tmp1
++	SLONGIFY($28)
++	ldl	$23,16($30)
++	sellt	$28,tmp1,$27,$27
++	ldl	tmp1,24($30)
++	addl	$30,STACK,$30
++	ret	$31,($23),1
++	.end	sfunction
++
++/*rem  32 */
++
++#undef DIV_ONLY
++#undef MOD_ONLY
++#undef func
++#undef modulus
++#undef quotient
++#undef GETSIGN
++#undef STACK
++#undef ufunction
++#undef sfunction
++#undef LONGIFY
++#undef SLONGIFY
++
++
++#undef DIV
++
++
++#ifdef DIV
++#define DIV_ONLY(x,y...) x,##y
++#define MOD_ONLY(x,y...)
++#define func(x) __div##x
++#define modulus $2
++#define quotient $27
++#define GETSIGN(x) xor $24,$25,x
++#define STACK 48
++#else
++#define DIV_ONLY(x,y...)
++#define MOD_ONLY(x,y...) x,##y
++#define func(x) __rem##x
++#define modulus $27
++#define quotient $2
++#define GETSIGN(x) bis $24,$24,x
++#define STACK 32
++#endif
++
++/*
++ * For 32-bit operations, we need to extend to 64-bit
++ */
++#ifdef INTSIZE
++#define ufunction func(wu)
++#define sfunction func(w)
++#define LONGIFY(x) zapnot x,15,x
++#define SLONGIFY(x)
++#else
++#define ufunction func(lu)
++#define sfunction func(l)
++#define LONGIFY(x)
++#define SLONGIFY(x)
++#endif
++
++.align	3
++.globl	ufunction
++.ent	ufunction
++ufunction:
++	subl	$30,STACK,$30
++	.frame	$30,STACK,$23
++	.prologue 0
++
++7:	stl	$1, 0($30)
++	bis	$25,$25,divisor
++	stl	$2, 8($30)
++	bis	$24,$24,modulus
++	stl	$0,16($30)
++	bis	$31,$31,quotient
++	LONGIFY(divisor)
++	stl	tmp1,24($30)
++	LONGIFY(modulus)
++	bis	$31,1,mask
++	DIV_ONLY(stl tmp2,32($30))
++	beq	divisor, 9f			/* div by zero */
++
++#ifdef INTSIZE
++	/*
++	 * shift divisor left, using 3-bit shifts for
++	 * 32-bit divides as we can't overflow. Three-bit
++	 * shifts will result in looping three times less
++	 * here, but can result in two loops more later.
++	 * Thus using a large shift isn't worth it (and
++	 * s8add pairs better than a sll..)
++	 */
++1:	cmpult	divisor,modulus,compare
++	s8addl	divisor,$31,divisor
++	s8addl	mask,$31,mask
++	bne	compare,1b
++#else
++1:	cmpult	divisor,modulus,compare
++	blt     divisor, 2f
++	addl	divisor,divisor,divisor
++	addl	mask,mask,mask
++	bne	compare,1b
++	nop
++#endif
++
++	/* ok, start to go right again.. */
++2:	DIV_ONLY(addl quotient,mask,tmp2)
++	srl	mask,1,mask
++	cmpule	divisor,modulus,compare
++	subl	modulus,divisor,tmp1
++	DIV_ONLY(selne compare,tmp2,quotient,quotient)
++	srl	divisor,1,divisor
++	selne	compare,tmp1,modulus,modulus
++	bne	mask,2b
++
++9:	ldl	$1, 0($30)
++	ldl	$2, 8($30)
++	ldl	$0,16($30)
++	ldl	tmp1,24($30)
++	DIV_ONLY(ldl tmp2,32($30))
++	addl	$30,STACK,$30
++	ret	$31,($23),1
++	.end	ufunction
++
++/*
++ * Uhh.. Ugly signed division. I'd rather not have it at all, but
++ * it's needed in some circumstances. There are different ways to
++ * handle this, really. This does:
++ * 	-a / b = a / -b = -(a / b)
++ *	-a % b = -(a % b)
++ *	a % -b = a % b
++ * which is probably not the best solution, but at least should
++ * have the property that (x/y)*y + (x%y) = x.
++ */
++.align 3
++.globl	sfunction
++.ent	sfunction
++sfunction:
++	subl	$30,STACK,$30
++	.frame	$30,STACK,$23
++	.prologue 0
++	bis	$24,$25,$28
++	SLONGIFY($28)
++	bge	$28,7b
++	stl	$24,0($30)
++	subl	$31,$24,$28
++	stl	$25,8($30)
++	sellt	$24,$28,$24,$24	/* abs($24) */
++	stl	$23,16($30)
++	subl	$31,$25,$28
++	stl	tmp1,24($30)
++	sellt	$25,$28,$25,$25	/* abs($25) */
++	nop
++	bsr	$23,ufunction
++	ldl	$24,0($30)
++	ldl	$25,8($30)
++	GETSIGN($28)
++	subl	$31,$27,tmp1
++	SLONGIFY($28)
++	ldl	$23,16($30)
++	sellt	$28,tmp1,$27,$27
++	ldl	tmp1,24($30)
++	addl	$30,STACK,$30
++	ret	$31,($23),1
++	.end	sfunction
++
++/*div 64*/
++
++#undef DIV_ONLY
++#undef MOD_ONLY
++#undef func
++#undef modulus
++#undef quotient
++#undef GETSIGN
++#undef STACK
++#undef ufunction
++#undef sfunction
++#undef LONGIFY
++#undef SLONGIFY
++
++
++#define DIV
++#undef INTSIZE
++
++#ifdef DIV
++#define DIV_ONLY(x,y...) x,##y
++#define MOD_ONLY(x,y...)
++#define func(x) __div##x
++#define modulus $2
++#define quotient $27
++#define GETSIGN(x) xor $24,$25,x
++#define STACK 48
++#else
++#define DIV_ONLY(x,y...)
++#define MOD_ONLY(x,y...) x,##y
++#define func(x) __rem##x
++#define modulus $27
++#define quotient $2
++#define GETSIGN(x) bis $24,$24,x
++#define STACK 32
++#endif
++
++/*
++ * For 32-bit operations, we need to extend to 64-bit
++ */
++#ifdef INTSIZE
++#define ufunction func(wu)
++#define sfunction func(w)
++#define LONGIFY(x) zapnot x,15,x
++#define SLONGIFY(x)
++#else
++#define ufunction func(lu)
++#define sfunction func(l)
++#define LONGIFY(x)
++#define SLONGIFY(x)
++#endif
++
++.align	3
++.globl	ufunction
++.ent	ufunction
++ufunction:
++	subl	$30,STACK,$30
++	.frame	$30,STACK,$23
++	.prologue 0
++
++7:	stl	$1, 0($30)
++	bis	$25,$25,divisor
++	stl	$2, 8($30)
++	bis	$24,$24,modulus
++	stl	$0,16($30)
++	bis	$31,$31,quotient
++	LONGIFY(divisor)
++	stl	tmp1,24($30)
++	LONGIFY(modulus)
++	bis	$31,1,mask
++	DIV_ONLY(stl tmp2,32($30))
++	beq	divisor, 9f			/* div by zero */
++
++#ifdef INTSIZE
++	/*
++	 * shift divisor left, using 3-bit shifts for
++	 * 32-bit divides as we can't overflow. Three-bit
++	 * shifts will result in looping three times less
++	 * here, but can result in two loops more later.
++	 * Thus using a large shift isn't worth it (and
++	 * s8add pairs better than a sll..)
++	 */
++1:	cmpult	divisor,modulus,compare
++	s8addl	divisor,$31,divisor
++	s8addl	mask,$31,mask
++	bne	compare,1b
++#else
++1:	cmpult	divisor,modulus,compare
++	blt     divisor, 2f
++	addl	divisor,divisor,divisor
++	addl	mask,mask,mask
++	bne	compare,1b
++	nop
++#endif
++
++	/* ok, start to go right again.. */
++2:	DIV_ONLY(addl quotient,mask,tmp2)
++	srl	mask,1,mask
++	cmpule	divisor,modulus,compare
++	subl	modulus,divisor,tmp1
++	DIV_ONLY(selne compare,tmp2,quotient,quotient)
++	srl	divisor,1,divisor
++	selne	compare,tmp1,modulus,modulus
++	bne	mask,2b
++
++9:	ldl	$1, 0($30)
++	ldl	$2, 8($30)
++	ldl	$0,16($30)
++	ldl	tmp1,24($30)
++	DIV_ONLY(ldl tmp2,32($30))
++	addl	$30,STACK,$30
++	ret	$31,($23),1
++	.end	ufunction
++
++/*
++ * Uhh.. Ugly signed division. I'd rather not have it at all, but
++ * it's needed in some circumstances. There are different ways to
++ * handle this, really. This does:
++ * 	-a / b = a / -b = -(a / b)
++ *	-a % b = -(a % b)
++ *	a % -b = a % b
++ * which is probably not the best solution, but at least should
++ * have the property that (x/y)*y + (x%y) = x.
++ */
++.align 3
++.globl	sfunction
++.ent	sfunction
++sfunction:
++	subl	$30,STACK,$30
++	.frame	$30,STACK,$23
++	.prologue 0
++	bis	$24,$25,$28
++	SLONGIFY($28)
++	bge	$28,7b
++	stl	$24,0($30)
++	subl	$31,$24,$28
++	stl	$25,8($30)
++	sellt	$24,$28,$24,$24	/* abs($24) */
++	stl	$23,16($30)
++	subl	$31,$25,$28
++	stl	tmp1,24($30)
++	sellt	$25,$28,$25,$25	/* abs($25) */
++	nop
++	bsr	$23,ufunction
++	ldl	$24,0($30)
++	ldl	$25,8($30)
++	GETSIGN($28)
++	subl	$31,$27,tmp1
++	SLONGIFY($28)
++	ldl	$23,16($30)
++	sellt	$28,tmp1,$27,$27
++	ldl	tmp1,24($30)
++	addl	$30,STACK,$30
++	ret	$31,($23),1
++	.end	sfunction
++
++
++/*rem 64*/
++
++#undef DIV_ONLY
++#undef MOD_ONLY
++#undef func
++#undef modulus
++#undef quotient
++#undef GETSIGN
++#undef STACK
++#undef ufunction
++#undef sfunction
++#undef LONGIFY
++#undef SLONGIFY
++
++
++#undef DIV
++
++#ifdef DIV
++#define DIV_ONLY(x,y...) x,##y
++#define MOD_ONLY(x,y...)
++#define func(x) __div##x
++#define modulus $2
++#define quotient $27
++#define GETSIGN(x) xor $24,$25,x
++#define STACK 48
++#else
++#define DIV_ONLY(x,y...)
++#define MOD_ONLY(x,y...) x,##y
++#define func(x) __rem##x
++#define modulus $27
++#define quotient $2
++#define GETSIGN(x) bis $24,$24,x
++#define STACK 32
++#endif
++
++/*
++ * For 32-bit operations, we need to extend to 64-bit
++ */
++#ifdef INTSIZE
++#define ufunction func(wu)
++#define sfunction func(w)
++#define LONGIFY(x) zapnot x,15,x
++#define SLONGIFY(x)
++#else
++#define ufunction func(lu)
++#define sfunction func(l)
++#define LONGIFY(x)
++#define SLONGIFY(x)
++#endif
++
++
++.align	3
++.globl	ufunction
++.ent	ufunction
++ufunction:
++	subl	$30,STACK,$30
++	.frame	$30,STACK,$23
++	.prologue 0
++
++7:	stl	$1, 0($30)
++	bis	$25,$25,divisor
++	stl	$2, 8($30)
++	bis	$24,$24,modulus
++	stl	$0,16($30)
++	bis	$31,$31,quotient
++	LONGIFY(divisor)
++	stl	tmp1,24($30)
++	LONGIFY(modulus)
++	bis	$31,1,mask
++	DIV_ONLY(stl tmp2,32($30))
++	beq	divisor, 9f			/* div by zero */
++
++#ifdef INTSIZE
++	/*
++	 * shift divisor left, using 3-bit shifts for
++	 * 32-bit divides as we can't overflow. Three-bit
++	 * shifts will result in looping three times less
++	 * here, but can result in two loops more later.
++	 * Thus using a large shift isn't worth it (and
++	 * s8add pairs better than a sll..)
++	 */
++1:	cmpult	divisor,modulus,compare
++	s8addl	divisor,$31,divisor
++	s8addl	mask,$31,mask
++	bne	compare,1b
++#else
++1:	cmpult	divisor,modulus,compare
++	blt     divisor, 2f
++	addl	divisor,divisor,divisor
++	addl	mask,mask,mask
++	bne	compare,1b
++	nop
++#endif
++
++	/* ok, start to go right again.. */
++2:	DIV_ONLY(addl quotient,mask,tmp2)
++	srl	mask,1,mask
++	cmpule	divisor,modulus,compare
++	subl	modulus,divisor,tmp1
++	DIV_ONLY(selne compare,tmp2,quotient,quotient)
++	srl	divisor,1,divisor
++	selne	compare,tmp1,modulus,modulus
++	bne	mask,2b
++
++9:	ldl	$1, 0($30)
++	ldl	$2, 8($30)
++	ldl	$0,16($30)
++	ldl	tmp1,24($30)
++	DIV_ONLY(ldl tmp2,32($30))
++	addl	$30,STACK,$30
++	ret	$31,($23),1
++	.end	ufunction
++
++/*
++ * Uhh.. Ugly signed division. I'd rather not have it at all, but
++ * it's needed in some circumstances. There are different ways to
++ * handle this, really. This does:
++ * 	-a / b = a / -b = -(a / b)
++ *	-a % b = -(a % b)
++ *	a % -b = a % b
++ * which is probably not the best solution, but at least should
++ * have the property that (x/y)*y + (x%y) = x.
++ */
++.align 3
++.globl	sfunction
++.ent	sfunction
++sfunction:
++	subl	$30,STACK,$30
++	.frame	$30,STACK,$23
++	.prologue 0
++	bis	$24,$25,$28
++	SLONGIFY($28)
++	bge	$28,7b
++	stl	$24,0($30)
++	subl	$31,$24,$28
++	stl	$25,8($30)
++	sellt	$24,$28,$24,$24	/* abs($24) */
++	stl	$23,16($30)
++	subl	$31,$25,$28
++	stl	tmp1,24($30)
++	sellt	$25,$28,$25,$25	/* abs($25) */
++	nop
++	bsr	$23,ufunction
++	ldl	$24,0($30)
++	ldl	$25,8($30)
++	GETSIGN($28)
++	subl	$31,$27,tmp1
++	SLONGIFY($28)
++	ldl	$23,16($30)
++	sellt	$28,tmp1,$27,$27
++	ldl	tmp1,24($30)
++	addl	$30,STACK,$30
++	ret	$31,($23),1
++	.end	sfunction
+diff --git a/grub-core/lib/sw64/setjmp.S b/grub-core/lib/sw64/setjmp.S
+new file mode 100644
+index 0000000..926f5fc
+--- /dev/null
++++ b/grub-core/lib/sw64/setjmp.S
+@@ -0,0 +1,75 @@
++/*
++ *  GRUB  --  GRand Unified Bootloader
++ *  Copyright (C) 2026  Free Software Foundation, Inc.
++ *
++ *  GRUB is free software: you can redistribute it and/or modify
++ *  it under the terms of the GNU General Public License as published by
++ *  the Free Software Foundation, either version 3 of the License, or
++ *  (at your option) any later version.
++ *
++ *  GRUB is distributed in the hope that it will be useful,
++ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *  GNU General Public License for more details.
++ *
++ *  You should have received a copy of the GNU General Public License
++ *  along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++#include <grub/symbol.h>
++#include <grub/dl.h>
++#include <grub/sw64/jmpbuf-offsets.h>
++#include <grub/sw64/regdef.h>
++
++       .file   "setjmp.S"
++
++GRUB_MOD_LICENSE "GPLv2+"
++
++FUNCTION(grub_setjmp)
++     ldgp    gp, 0(pv)
++#define FRAME  0
++     .frame  sp, FRAME, ra, 0
++
++     stl       s0, JB_S0*8(a0)
++     stl       s1, JB_S1*8(a0)
++     stl       s2, JB_S2*8(a0)
++     stl       s3, JB_S3*8(a0)
++     stl       s4, JB_S4*8(a0)
++     stl       s5, JB_S5*8(a0)
++     stl       ra, JB_PC*8(a0)
++     addl      sp, FRAME, t1
++     stl       t1, JB_SP*8(a0)
++     stl       fp, JB_FP*8(a0)
++     fstd      $f2, JB_F2*8(a0)
++     fstd      $f3, JB_F3*8(a0)
++     fstd      $f4, JB_F4*8(a0)
++     fstd      $f5, JB_F5*8(a0)
++     fstd      $f6, JB_F6*8(a0)
++     fstd      $f7, JB_F7*8(a0)
++     fstd      $f8, JB_F8*8(a0)
++     fstd      $f9, JB_F9*8(a0)
++     ldi       a0, 0($31)
++     ret
++
++FUNCTION(grub_longjmp)
++     mov       a1, v0
++     ldl       s0, JB_S0*8(a0)
++     ldl       s1, JB_S1*8(a0)
++     ldl       s2, JB_S2*8(a0)
++     ldl       s3, JB_S3*8(a0)
++     ldl       s4, JB_S4*8(a0)
++     ldl       s5, JB_S5*8(a0)
++     ldl       ra, JB_PC*8(a0)
++     ldl       fp, JB_FP*8(a0)
++     ldl       t0, JB_SP*8(a0)
++     fldd      $f2, JB_F2*8(a0)
++     fldd      $f3, JB_F3*8(a0)
++     fldd      $f4, JB_F4*8(a0)
++     fldd      $f5, JB_F5*8(a0)
++     fldd      $f6, JB_F6*8(a0)
++     fldd      $f7, JB_F7*8(a0)
++     fldd      $f8, JB_F8*8(a0)
++     fldd      $f9, JB_F9*8(a0)
++     seleq     v0, 1, v0, v0
++     mov       t0, sp
++     ret
+diff --git a/include/grub/efi/efi.h b/include/grub/efi/efi.h
+index a5cd99e..26f4735 100644
+--- a/include/grub/efi/efi.h
++++ b/include/grub/efi/efi.h
+@@ -122,7 +122,7 @@ extern void (*EXPORT_VAR(grub_efi_net_config)) (grub_efi_handle_t hnd,
+ void *
+ EXPORT_FUNC (grub_efi_find_configuration_table) (const grub_guid_t *target_guid);
+ 
+-#if defined(__arm__) || defined(__aarch64__) || defined(__riscv) || defined(__loongarch__)
++#if defined(__arm__) || defined(__aarch64__) || defined(__riscv) || defined(__loongarch__) || defined (__sw_64__)
+ void *EXPORT_FUNC(grub_efi_get_firmware_fdt)(void);
+ grub_err_t EXPORT_FUNC(grub_efi_get_ram_base)(grub_addr_t *);
+ #endif
+diff --git a/include/grub/sw64/divide.h b/include/grub/sw64/divide.h
+new file mode 100644
+index 0000000..a6c8eae
+--- /dev/null
++++ b/include/grub/sw64/divide.h
+@@ -0,0 +1,11 @@
++#ifndef __DIVIDE_H__
++#define __DIVIDE_H__
++void EXPORT_FUNC(__divw) (void);
++void EXPORT_FUNC(__remw) (void);
++void EXPORT_FUNC(__divl) (void);
++void EXPORT_FUNC(__reml) (void);
++void EXPORT_FUNC(__divwu) (void);
++void EXPORT_FUNC(__remwu) (void);
++void EXPORT_FUNC(__divlu) (void);
++void EXPORT_FUNC(__remlu) (void);
++#endif
+diff --git a/include/grub/sw64/efi/memory.h b/include/grub/sw64/efi/memory.h
+new file mode 100644
+index 0000000..b869f46
+--- /dev/null
++++ b/include/grub/sw64/efi/memory.h
+@@ -0,0 +1,7 @@
++#ifndef GRUB_MEMORY_CPU_HEADER
++#include <grub/efi/memory.h>
++
++#define GRUB_EFI_MAX_USABLE_ADDRESS 0xFFF000003FFFFFFFULL
++#define GRUB_EFI_MAX_ALLOCATION_ADDRESS GRUB_EFI_MAX_USABLE_ADDRESS
++
++#endif /* ! GRUB_MEMORY_CPU_HEADER */
+diff --git a/include/grub/sw64/efi/time.h b/include/grub/sw64/efi/time.h
+new file mode 100644
+index 0000000..b90bcb4
+--- /dev/null
++++ b/include/grub/sw64/efi/time.h
+@@ -0,0 +1,23 @@
++/*
++ *  GRUB  --  GRand Unified Bootloader
++ *  Copyright (C) 2026  Free Software Foundation, Inc.
++ *
++ *  GRUB is free software: you can redistribute it and/or modify
++ *  it under the terms of the GNU General Public License as published by
++ *  the Free Software Foundation, either version 3 of the License, or
++ *  (at your option) any later version.
++ *
++ *  GRUB is distributed in the hope that it will be useful,
++ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *  GNU General Public License for more details.
++ *
++ *  You should have received a copy of the GNU General Public License
++ *  along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
++ */
++#ifndef GRUB_MACHINE_TIME_HEADER
++#define GRUB_MACHINE_TIME_HEADER	1
++
++#include <grub/efi/time.h>
++
++#endif /* ! GRUB_MACHINE_TIME_HEADER */
+diff --git a/include/grub/sw64/io.h b/include/grub/sw64/io.h
+new file mode 100644
+index 0000000..851eff5
+--- /dev/null
++++ b/include/grub/sw64/io.h
+@@ -0,0 +1,62 @@
++/*
++ *  GRUB  --  GRand Unified Bootloader
++ *  Copyright (C) 2026  Free Software Foundation, Inc.
++ *
++ *  GRUB is free software: you can redistribute it and/or modify
++ *  it under the terms of the GNU General Public License as published by
++ *  the Free Software Foundation, either version 3 of the License, or
++ *  (at your option) any later version.
++ *
++ *  GRUB is distributed in the hope that it will be useful,
++ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *  GNU General Public License for more details.
++ *
++ *  You should have received a copy of the GNU General Public License
++ *  along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++#ifndef	GRUB_IO_H
++#define	GRUB_IO_H	1
++
++#include <grub/types.h>
++
++typedef grub_addr_t grub_port_t;
++
++static __inline unsigned char
++grub_inb (grub_port_t port)
++{
++  return *(volatile grub_uint8_t *) port;
++}
++
++static __inline unsigned short int
++grub_inw (grub_port_t port)
++{
++  return *(volatile grub_uint16_t *) port;
++}
++
++static __inline unsigned int
++grub_inl (grub_port_t port)
++{
++  return *(volatile grub_uint32_t *) port;
++}
++
++static __inline void
++grub_outb (unsigned char value, grub_port_t port)
++{
++  *(volatile grub_uint8_t *) port = value;
++}
++
++static __inline void
++grub_outw (unsigned short int value, grub_port_t port)
++{
++  *(volatile grub_uint16_t *) port = value;
++}
++
++static __inline void
++grub_outl (unsigned int value, grub_port_t port)
++{
++  *(volatile grub_uint32_t *) port = value;
++}
++
++#endif /* _SYS_IO_H */
+diff --git a/include/grub/sw64/jmpbuf-offsets.h b/include/grub/sw64/jmpbuf-offsets.h
+new file mode 100644
+index 0000000..7ab64a2
+--- /dev/null
++++ b/include/grub/sw64/jmpbuf-offsets.h
+@@ -0,0 +1,35 @@
++/* Private macros for accessing __jmp_buf contents.  Alpha version.
++   Copyright (C) 2006-2026 Free Software Foundation, Inc.
++   This file is part of the GNU C Library.
++
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public
++   License as published by the Free Software Foundation; either
++   version 2.1 of the License, or (at your option) any later version.
++
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library.  If not, see
++   <http://www.gnu.org/licenses/>.  */
++
++#define JB_S0  0
++#define JB_S1  1
++#define JB_S2  2
++#define JB_S3  3
++#define JB_S4  4
++#define JB_S5  5
++#define JB_PC  6
++#define JB_FP  7
++#define JB_SP  8
++#define JB_F2  9
++#define JB_F3  10
++#define JB_F4  11
++#define JB_F5  12
++#define JB_F6  13
++#define JB_F7  14
++#define JB_F8  15
++#define JB_F9  16
+diff --git a/include/grub/sw64/kernel.h b/include/grub/sw64/kernel.h
+new file mode 100644
+index 0000000..237d920
+--- /dev/null
++++ b/include/grub/sw64/kernel.h
+@@ -0,0 +1,25 @@
++/*
++ *  GRUB  --  GRand Unified Bootloader
++ *  Copyright (C) 2026  Free Software Foundation, Inc.
++ *
++ *  GRUB is free software: you can redistribute it and/or modify
++ *  it under the terms of the GNU General Public License as published by
++ *  the Free Software Foundation, either version 3 of the License, or
++ *  (at your option) any later version.
++ *
++ *  GRUB is distributed in the hope that it will be useful,
++ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *  GNU General Public License for more details.
++ *
++ *  You should have received a copy of the GNU General Public License
++ *  along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++#ifndef GRUB_CPU_KERNEL_HEADER
++#define GRUB_CPU_KERNEL_HEADER   1
++
++#define GRUB_MOD_ALIGN	0x1
++#define GRUB_MOD_GAP	0x0
++
++#endif /* ! GRUB_CPU_KERNEL_HEADER */
+diff --git a/include/grub/sw64/regdef.h b/include/grub/sw64/regdef.h
+new file mode 100644
+index 0000000..b30eb77
+--- /dev/null
++++ b/include/grub/sw64/regdef.h
+@@ -0,0 +1,44 @@
++#ifndef __sw_regdef_h__
++#define __sw_regdef_h__
++
++#define v0	$0	/* function return value */
++
++#define t0	$1	/* temporary registers (caller-saved) */
++#define t1	$2
++#define t2	$3
++#define t3	$4
++#define t4	$5
++#define t5	$6
++#define t6	$7
++#define t7	$8
++
++#define	s0	$9	/* saved-registers (callee-saved registers) */
++#define	s1	$10
++#define	s2	$11
++#define	s3	$12
++#define	s4	$13
++#define	s5	$14
++#define	s6	$15
++#define	fp	s6	/* frame-pointer (s6 in frame-less procedures) */
++
++#define a0	$16	/* argument registers (caller-saved) */
++#define a1	$17
++#define a2	$18
++#define a3	$19
++#define a4	$20
++#define a5	$21
++
++#define t8	$22	/* more temps (caller-saved) */
++#define t9	$23
++#define t10	$24
++#define t11	$25
++#define ra	$26	/* return address register */
++#define t12	$27
++
++#define pv	t12	/* procedure-variable register */
++#define AT	$at	/* assembler temporary */
++#define gp	$29	/* global pointer */
++#define sp	$30	/* stack pointer */
++#define zero	$31	/* reads as zero, writes are noops */
++
++#endif /* __sw_64_regdef_h__ */
+diff --git a/include/grub/sw64/setjmp.h b/include/grub/sw64/setjmp.h
+new file mode 100644
+index 0000000..956690d
+--- /dev/null
++++ b/include/grub/sw64/setjmp.h
+@@ -0,0 +1,27 @@
++/* Define the machine-dependent type `jmp_buf'.  Linux/SW64 version.
++   Copyright (C) 1999, 2000, 2008, 2026  Free Software Foundation, Inc.
++
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Library General Public License as
++   published by the Free Software Foundation; either version 2 of the
++   License, or (at your option) any later version.
++
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Library General Public License for more details.
++
++   You should have received a copy of the GNU Library General Public
++   License along with the GNU C Library; see the file COPYING.LIB.  If not,
++   write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
++   Boston, MA 02111-1307, USA.  */
++
++/* User code must not depend on the internal representation of jmp_buf. */
++
++#define _JBLEN	70
++
++/* the __jmp_buf element type should be __float80 per ABI... */
++typedef long grub_jmp_buf[_JBLEN] __attribute__ ((aligned (16))); /* guarantees 128-bit alignment! */
++
++int grub_setjmp (grub_jmp_buf env);
++void grub_longjmp (grub_jmp_buf env, int val) __attribute__ ((noreturn));
+diff --git a/include/grub/sw64/time.h b/include/grub/sw64/time.h
+new file mode 100644
+index 0000000..fc866fe
+--- /dev/null
++++ b/include/grub/sw64/time.h
+@@ -0,0 +1,28 @@
++/*
++ *  GRUB  --  GRand Unified Bootloader
++ *  Copyright (C) 2007, 2008, 2026  Free Software Foundation, Inc.
++ *
++ *  GRUB is free software: you can redistribute it and/or modify
++ *  it under the terms of the GNU General Public License as published by
++ *  the Free Software Foundation, either version 3 of the License, or
++ *  (at your option) any later version.
++ *
++ *  GRUB is distributed in the hope that it will be useful,
++ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *  GNU General Public License for more details.
++ *
++ *  You should have received a copy of the GNU General Public License
++ *  along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++#ifndef KERNEL_CPU_TIME_HEADER
++#define KERNEL_CPU_TIME_HEADER	1
++
++static __inline void
++grub_cpu_idle (void)
++{
++  /* FIXME: not implemented */
++}
++
++#endif /* ! KERNEL_CPU_TIME_HEADER */
+diff --git a/include/grub/sw64/types.h b/include/grub/sw64/types.h
+new file mode 100644
+index 0000000..78b2136
+--- /dev/null
++++ b/include/grub/sw64/types.h
+@@ -0,0 +1,32 @@
++/*
++ *  GRUB  --  GRand Unified Bootloader
++ *  Copyright (C) 2026  Free Software Foundation, Inc.
++ *
++ *  GRUB is free software: you can redistribute it and/or modify
++ *  it under the terms of the GNU General Public License as published by
++ *  the Free Software Foundation, either version 3 of the License, or
++ *  (at your option) any later version.
++ *
++ *  GRUB is distributed in the hope that it will be useful,
++ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *  GNU General Public License for more details.
++ *
++ *  You should have received a copy of the GNU General Public License
++ *  along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++#ifndef GRUB_TYPES_CPU_HEADER
++#define GRUB_TYPES_CPU_HEADER	1
++
++/* The size of void *.  */
++#define GRUB_TARGET_SIZEOF_VOID_P	8
++
++/* The size of long.  */
++#define GRUB_TARGET_SIZEOF_LONG		8
++
++/* sw64 is little-endian (usually).  */
++#undef GRUB_TARGET_WORDS_BIGENDIAN
++
++
++#endif /* ! GRUB_TYPES_CPU_HEADER */
+-- 
+2.20.1
+

--- a/debian/patches/sw64/0005-sw64-Add-to-build-system.patch
+++ b/debian/patches/sw64/0005-sw64-Add-to-build-system.patch
@@ -1,0 +1,514 @@
+From edf244802c21a42e46d1c1280892a31094d15a87 Mon Sep 17 00:00:00 2001
+From: sunway_fw <sunway_fw@wxiat.com>
+Date: Thu, 14 May 2026 15:33:57 +0800
+Subject: [PATCH] sw64: Add to build system
+
+This patch adds SW64 to the GRUB build system and various tools, so GRUB
+can be built on SW64 as a UEFI application.
+
+Signed-off-by: sunway_fw <sunway_fw@wxiat.com>
+---
+ Makefile.util.def            |  1 +
+ conf/Makefile.common         |  3 +++
+ configure.ac                 |  4 ++++
+ gentpl.py                    |  7 ++++---
+ grub-core/Makefile.am        |  7 +++++++
+ grub-core/Makefile.core.def  | 20 ++++++++++++++++++++
+ grub-core/commands/file.c    | 11 ++++++++++-
+ grub-core/kern/compiler-rt.c |  2 +-
+ grub-core/lib/setjmp.S       |  2 ++
+ include/grub/compiler-rt.h   |  2 +-
+ include/grub/efi/pe32.h      |  1 +
+ include/grub/util/install.h  |  1 +
+ util/grub-install-common.c   |  1 +
+ util/grub-install.c          | 13 +++++++++++++
+ util/grub-mknetdir.c         |  1 +
+ util/grub-mkrescue.c         | 10 ++++++++--
+ util/mkimage.c               | 16 ++++++++++++++++
+ 17 files changed, 94 insertions(+), 8 deletions(-)
+
+diff --git a/Makefile.util.def b/Makefile.util.def
+index e82e89c..88f80a7 100644
+--- a/Makefile.util.def
++++ b/Makefile.util.def
+@@ -164,6 +164,7 @@ library = {
+   common = grub-core/kern/arm/dl_helper.c;
+   common = grub-core/kern/arm64/dl_helper.c;
+   common = grub-core/kern/loongarch64/dl_helper.c;
++  common = grub-core/kern/sw64/dl_helper.c;
+   common = grub-core/lib/minilzo/minilzo.c;
+   common = grub-core/lib/xzembed/xz_dec_bcj.c;
+   common = grub-core/lib/xzembed/xz_dec_lzma2.c;
+diff --git a/conf/Makefile.common b/conf/Makefile.common
+index b8f216f..f3ab6b9 100644
+--- a/conf/Makefile.common
++++ b/conf/Makefile.common
+@@ -23,6 +23,9 @@ endif
+ if COND_HAVE_PCI
+   CFLAGS_PLATFORM += -DGRUB_HAS_PCI
+ endif
++if COND_sw_64_efi
++  CFLAGS_PLATFORM += -Wno-packed-not-aligned -Wno-cast-align -Wno-sign-compare
++endif
+ 
+ # Other options
+ 
+diff --git a/configure.ac b/configure.ac
+index 0cc2b96..672382a 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -126,6 +126,7 @@ case "$target_cpu" in
+   loongarch64)	target_cpu=loongarch64 ;;
+   riscv32*)	target_cpu=riscv32 ;;
+   riscv64*)	target_cpu=riscv64 ;;
++  sw_64*)       target_cpu=sw64;;
+ esac
+ 
+ # Specify the platform (such as firmware).
+@@ -153,6 +154,7 @@ if test "x$with_platform" = x; then
+     loongarch64-*) platform=efi;;
+     riscv32-*) platform=efi ;;
+     riscv64-*) platform=efi ;;
++    sw64-*) platform=efi ;;
+     *)
+       AC_MSG_WARN([unsupported CPU: "$target_cpu" - only building utilities])
+       platform=none
+@@ -205,6 +207,7 @@ case "$target_cpu"-"$platform" in
+   loongarch64-efi) ;;
+   riscv32-efi) ;;
+   riscv64-efi) ;;
++  sw64-efi) ;;
+   *-emu) ;;
+   *-none) ;;
+   *) AC_MSG_ERROR([platform "$platform" is not supported for target CPU "$target_cpu"]) ;;
+@@ -2234,6 +2237,7 @@ AM_CONDITIONAL([COND_riscv32], [test x$target_cpu = xriscv32 ])
+ AM_CONDITIONAL([COND_riscv64], [test x$target_cpu = xriscv64 ])
+ AM_CONDITIONAL([COND_riscv32_efi], [test x$target_cpu = xriscv32 -a x$platform = xefi])
+ AM_CONDITIONAL([COND_riscv64_efi], [test x$target_cpu = xriscv64 -a x$platform = xefi])
++AM_CONDITIONAL([COND_sw_64_efi], [test x$target_cpu = xsw64 -a x$platform = xefi])
+ AM_CONDITIONAL([COND_sparc64_ieee1275], [test x$target_cpu = xsparc64 -a x$platform = xieee1275])
+ AM_CONDITIONAL([COND_sparc64_emu], [test x$target_cpu = xsparc64 -a x$platform = xemu])
+ AM_CONDITIONAL([COND_x86_64_efi], [test x$target_cpu = xx86_64 -a x$platform = xefi])
+diff --git a/gentpl.py b/gentpl.py
+index 3a19687..08dd41c 100644
+--- a/gentpl.py
++++ b/gentpl.py
+@@ -32,7 +32,7 @@ GRUB_PLATFORMS = [ "emu", "i386_pc", "i386_efi", "i386_qemu", "i386_coreboot",
+                    "mips_loongson", "mips64_efi", "sparc64_ieee1275",
+                    "powerpc_ieee1275", "mips_arc", "ia64_efi",
+                    "mips_qemu_mips", "arm_uboot", "arm_efi", "arm64_efi",
+-                   "arm_coreboot", "loongarch64_efi", "riscv32_efi", "riscv64_efi" ]
++                   "arm_coreboot", "loongarch64_efi", "riscv32_efi", "riscv64_efi", "sw_64_efi" ]
+ 
+ GROUPS = {}
+ 
+@@ -51,10 +51,11 @@ GROUPS["arm64"]       = [ "arm64_efi" ]
+ GROUPS["loongarch64"] = [ "loongarch64_efi" ]
+ GROUPS["riscv32"]     = [ "riscv32_efi" ]
+ GROUPS["riscv64"]     = [ "riscv64_efi" ]
++GROUPS["sw_64"]       = [ "sw_64_efi" ]
+ 
+ # Groups based on firmware
+ GROUPS["efi"]  = [ "i386_efi", "x86_64_efi", "ia64_efi", "arm_efi", "arm64_efi", "mips64_efi",
+-		   "loongarch64_efi", "riscv32_efi", "riscv64_efi" ]
++		   "loongarch64_efi", "riscv32_efi", "riscv64_efi", "sw_64_efi" ]
+ GROUPS["ieee1275"]   = [ "i386_ieee1275", "sparc64_ieee1275", "powerpc_ieee1275" ]
+ GROUPS["uboot"] = [ "arm_uboot" ]
+ GROUPS["xen"]  = [ "i386_xen", "x86_64_xen" ]
+@@ -81,7 +82,7 @@ GROUPS["terminfomodule"]   = GRUB_PLATFORMS[:];
+ for i in GROUPS["terminfoinkernel"]: GROUPS["terminfomodule"].remove(i)
+ 
+ # Flattened Device Trees (FDT)
+-GROUPS["fdt"] = [ "arm64_efi", "arm_uboot", "arm_efi", "loongarch64_efi", "riscv32_efi", "riscv64_efi" ]
++GROUPS["fdt"] = [ "arm64_efi", "arm_uboot", "arm_efi", "loongarch64_efi", "riscv32_efi", "riscv64_efi", "sw_64_efi" ]
+ 
+ # Needs software helpers for division
+ # Must match GRUB_DIVISION_IN_SOFTWARE in misc.h
+diff --git a/grub-core/Makefile.am b/grub-core/Makefile.am
+index 3966a0f..120afaa 100644
+--- a/grub-core/Makefile.am
++++ b/grub-core/Makefile.am
+@@ -317,6 +317,13 @@ KERNEL_HEADER_FILES += $(top_srcdir)/include/grub/efi/disk.h
+ KERNEL_HEADER_FILES += $(top_srcdir)/include/grub/acpi.h
+ endif
+ 
++if COND_sw_64_efi
++KERNEL_HEADER_FILES += $(top_srcdir)/include/grub/efi/efi.h
++KERNEL_HEADER_FILES += $(top_srcdir)/include/grub/efi/disk.h
++KERNEL_HEADER_FILES += $(top_srcdir)/include/grub/sw64/divide.h
++KERNEL_HEADER_FILES += $(top_srcdir)/include/grub/acpi.h
++endif
++
+ if COND_emu
+ KERNEL_HEADER_FILES += $(top_srcdir)/include/grub/datetime.h
+ KERNEL_HEADER_FILES += $(top_srcdir)/include/grub/emu/misc.h
+diff --git a/grub-core/Makefile.core.def b/grub-core/Makefile.core.def
+index 393ccde..ac1b980 100644
+--- a/grub-core/Makefile.core.def
++++ b/grub-core/Makefile.core.def
+@@ -103,6 +103,8 @@ kernel = {
+   sparc64_ieee1275_ldflags = '-Wl,-Ttext,0x4400';
+   mips_arc_ldflags    = '-Wl,-Ttext,$(TARGET_LINK_ADDR)';
+   mips_qemu_mips_ldflags    = '-Wl,-Ttext,0x80200000';
++  sw_64_efi_ldflags = '-Wl,-r,-d';
++  sw_64_efi_stripflags = '--strip-unneeded -K start -R .note -R .comment -R .note.gnu.gold-version';
+ 
+   mips_arc_cppflags = '-DGRUB_DECOMPRESSOR_LINK_ADDR=$(TARGET_DECOMPRESSOR_LINK_ADDR)';
+   i386_qemu_cppflags     = '-DGRUB_BOOT_MACHINE_LINK_ADDR=$(GRUB_BOOT_MACHINE_LINK_ADDR)';
+@@ -137,6 +139,7 @@ kernel = {
+   loongarch64_efi_startup = kern/loongarch64/efi/startup.S;
+   riscv32_efi_startup = kern/riscv/efi/startup.S;
+   riscv64_efi_startup = kern/riscv/efi/startup.S;
++  sw_64_efi_startup = kern/sw64/efi/startup.S;
+ 
+   common = kern/buffer.c;
+   common = kern/command.c;
+@@ -341,6 +344,16 @@ kernel = {
+   mips64_efi = lib/mips64/efi/loongson.c;
+   mips64_efi = lib/mips64/efi/loongson_asm.S;
+ 
++  sw_64_efi = kern/sw64/dl.c;
++  sw_64_efi = kern/sw64/dl_helper.c;
++  sw_64_efi = kern/sw64/efi/init.c;
++  sw_64_efi = kern/efi/fdt.c;
++  sw_64_efi = lib/sw64/divide.S;
++  sw_64_efi = kern/sw64/efi/callwrap.S;
++  sw_64_efi = kern/sw64/cache.c;
++  sw_64_efi = kern/sw64/cache_flush.S;
++  sw_64_efi = commands/keylayouts.c;
++
+   powerpc_ieee1275 = kern/powerpc/cache.S;
+   powerpc_ieee1275 = kern/powerpc/dl.c;
+   powerpc_ieee1275 = kern/powerpc/compiler-rt.S;
+@@ -885,6 +898,7 @@ module = {
+   enable = loongarch64_efi;
+   enable = riscv32_efi;
+   enable = riscv64_efi;
++  enable = sw_64_efi;
+ };
+ 
+ module = {
+@@ -962,6 +976,7 @@ module = {
+   i386_multiboot = commands/acpihalt.c;
+   i386_efi = commands/acpihalt.c;
+   x86_64_efi = commands/acpihalt.c;
++  sw_64_efi = commands/acpihalt.c;
+   i386_multiboot = lib/i386/halt.c;
+   i386_coreboot = lib/i386/halt.c;
+   i386_qemu = lib/i386/halt.c;
+@@ -1799,6 +1814,8 @@ module = {
+   extra_dist = lib/arm64/setjmp.S;
+   extra_dist = lib/riscv/setjmp.S;
+   extra_dist = lib/loongarch64/setjmp.S;
++  extra_dist = lib/sw64/setjmp.S;
++  extra_dist = lib/sw64/divide.S;
+ };
+ 
+ module = {
+@@ -1904,6 +1921,7 @@ module = {
+   loongarch64 = loader/efi/linux.c;
+   riscv32 = loader/efi/linux.c;
+   riscv64 = loader/efi/linux.c;
++  sw_64_efi = loader/sw64/efi/linux.c;
+   i386_efi = loader/efi/linux.c;
+   x86_64_efi = loader/efi/linux.c;
+   emu = loader/emu/linux.c;
+@@ -1921,6 +1939,7 @@ module = {
+   enable = riscv32_efi;
+   enable = riscv64_efi;
+   enable = loongarch64_efi;
++  enable = sw_64;
+ };
+ 
+ 
+@@ -2018,6 +2037,7 @@ module = {
+   enable = riscv64_efi;
+   enable = mips;
+   enable = mips64_efi;
++  enable = sw_64_efi;
+ };
+ 
+ module = {
+diff --git a/grub-core/commands/file.c b/grub-core/commands/file.c
+index 7c13e97..fd073f4 100644
+--- a/grub-core/commands/file.c
++++ b/grub-core/commands/file.c
+@@ -94,6 +94,8 @@ static const struct grub_arg_option options[] = {
+    N_("Check if FILE is RISC-V 32bit EFI file"), 0, 0},
+   {"is-riscv64-efi", 0, 0,
+    N_("Check if FILE is RISC-V 64bit EFI file"), 0, 0},
++  {"is-sw64-efi", 0, 0,
++   N_("Check if FILE is SW64 EFI file"), 0, 0},
+   {"is-hibernated-hiberfil", 0, 0,
+    N_("Check if FILE is hiberfil.sys in hibernated state"), 0, 0},
+   {"is-x86_64-xnu", 0, 0,
+@@ -136,6 +138,7 @@ enum
+   IS_ARM_EFI,
+   IS_RISCV32_EFI,
+   IS_RISCV64_EFI,
++  IS_SW64_EFI,
+   IS_HIBERNATED,
+   IS_XNU64,
+   IS_XNU32,
+@@ -590,6 +593,7 @@ grub_cmd_file (grub_extcmd_context_t ctxt, int argc, char **args)
+     case IS_ARM_EFI:
+     case IS_RISCV32_EFI:
+     case IS_RISCV64_EFI:
++    case IS_SW64_EFI:
+       {
+ 	char signature[4];
+ 	grub_uint32_t pe_offset;
+@@ -640,8 +644,13 @@ grub_cmd_file (grub_extcmd_context_t ctxt, int argc, char **args)
+ 	    grub_cpu_to_le16_compile_time (GRUB_PE32_MACHINE_RISCV64))
+           /* TODO: Determine bitness dynamically */
+ 	  break;
++        if (type == IS_SW64_EFI
++            && coff_head.machine !=
++            grub_cpu_to_le16_compile_time (GRUB_PE32_MACHINE_SW_64))
++          /* TODO: Determine bitness dynamically */
++	  break;
+ 	if (type == IS_IA_EFI || type == IS_64_EFI || type == IS_ARM64_EFI ||
+-	    type == IS_RISCV32_EFI || type == IS_RISCV64_EFI)
++	    type == IS_RISCV32_EFI || type == IS_RISCV64_EFI || type == IS_SW64_EFI)
+ 	  {
+ 	    struct grub_pe64_optional_header o64;
+ 	    if (grub_file_read (file, &o64, sizeof (o64)) != sizeof (o64))
+diff --git a/grub-core/kern/compiler-rt.c b/grub-core/kern/compiler-rt.c
+index eda689a..5dbada2 100644
+--- a/grub-core/kern/compiler-rt.c
++++ b/grub-core/kern/compiler-rt.c
+@@ -335,7 +335,7 @@ __ucmpdi2 (grub_uint64_t a, grub_uint64_t b)
+ #endif
+ 
+ #if defined (__powerpc__) || defined(__mips__) || defined(__sparc__) || \
+-    defined(__arm__) || defined(__riscv)
++    defined(__arm__) || defined(__riscv) || defined(__sw_64__)
+ 
+ /* Based on libgcc2.c from gcc suite.  */
+ grub_uint32_t
+diff --git a/grub-core/lib/setjmp.S b/grub-core/lib/setjmp.S
+index c213cc1..8bfb70e 100644
+--- a/grub-core/lib/setjmp.S
++++ b/grub-core/lib/setjmp.S
+@@ -27,6 +27,8 @@
+ #include "./loongarch64/setjmp.S"
+ #elif defined(__riscv)
+ #include "./riscv/setjmp.S"
++#elif defined(__sw_64__)
++#include "./sw64/setjmp.S"
+ #else
+ #error "Unknown target cpu type"
+ #endif
+diff --git a/include/grub/compiler-rt.h b/include/grub/compiler-rt.h
+index 17828b3..a8782fc 100644
+--- a/include/grub/compiler-rt.h
++++ b/include/grub/compiler-rt.h
+@@ -178,7 +178,7 @@ EXPORT_FUNC (__lshrdi3) (grub_uint64_t u, int b);
+ #endif
+ 
+ #if defined (__powerpc__) || defined(__mips__) || defined(__sparc__) || \
+-    defined (__arm__) || defined(__riscv)
++    defined (__arm__) || defined(__riscv) || defined(__sw_64__)
+ grub_uint32_t
+ EXPORT_FUNC(__bswapsi2) (grub_uint32_t u);
+ 
+diff --git a/include/grub/efi/pe32.h b/include/grub/efi/pe32.h
+index 5609d9b..40a1c48 100644
+--- a/include/grub/efi/pe32.h
++++ b/include/grub/efi/pe32.h
+@@ -93,6 +93,7 @@ struct grub_pe32_coff_header
+ #define GRUB_PE32_MACHINE_LOONGARCH64		0x6264
+ #define GRUB_PE32_MACHINE_RISCV32		0x5032
+ #define GRUB_PE32_MACHINE_RISCV64		0x5064
++#define GRUB_PE32_MACHINE_SW_64                 0x0284
+ 
+ #define GRUB_PE32_RELOCS_STRIPPED		0x0001
+ #define GRUB_PE32_EXECUTABLE_IMAGE		0x0002
+diff --git a/include/grub/util/install.h b/include/grub/util/install.h
+index 58424c5..d8501ed 100644
+--- a/include/grub/util/install.h
++++ b/include/grub/util/install.h
+@@ -110,6 +110,7 @@ enum grub_install_plat
+     GRUB_INSTALL_PLATFORM_LOONGARCH64_EFI,
+     GRUB_INSTALL_PLATFORM_RISCV32_EFI,
+     GRUB_INSTALL_PLATFORM_RISCV64_EFI,
++    GRUB_INSTALL_PLATFORM_SW64_EFI,
+     GRUB_INSTALL_PLATFORM_MIPS64EL_EFI,
+     GRUB_INSTALL_PLATFORM_MAX
+   };
+diff --git a/util/grub-install-common.c b/util/grub-install-common.c
+index 365e494..2045eb6 100644
+--- a/util/grub-install-common.c
++++ b/util/grub-install-common.c
+@@ -953,6 +953,7 @@ static struct
+     [GRUB_INSTALL_PLATFORM_LOONGARCH64_EFI] =  { "loongarch64", "efi"       },
+     [GRUB_INSTALL_PLATFORM_RISCV32_EFI] =      { "riscv32",     "efi"       },
+     [GRUB_INSTALL_PLATFORM_RISCV64_EFI] =      { "riscv64",     "efi"       },
++    [GRUB_INSTALL_PLATFORM_SW64_EFI] =         { "sw64",        "efi"       },
+   };
+ 
+ char *
+diff --git a/util/grub-install.c b/util/grub-install.c
+index a0eebae..b6acee6 100644
+--- a/util/grub-install.c
++++ b/util/grub-install.c
+@@ -364,6 +364,8 @@ get_default_platform (void)
+    return "riscv32-efi";
+ #elif __riscv_xlen == 64
+    return "riscv64-efi";
++#elif defined (__sw_64__)
++   return "sw64-efi";
+ #else
+    return NULL;
+ #endif
+@@ -544,6 +546,7 @@ have_bootdev (enum grub_install_plat pl)
+     case GRUB_INSTALL_PLATFORM_I386_XEN:
+     case GRUB_INSTALL_PLATFORM_X86_64_XEN:
+     case GRUB_INSTALL_PLATFORM_I386_XEN_PVH:
++    case GRUB_INSTALL_PLATFORM_SW64_EFI:
+       return 0;
+ 
+       /* pacify warning.  */
+@@ -1061,6 +1064,7 @@ main (int argc, char *argv[])
+     case GRUB_INSTALL_PLATFORM_I386_XEN:
+     case GRUB_INSTALL_PLATFORM_X86_64_XEN:
+     case GRUB_INSTALL_PLATFORM_I386_XEN_PVH:
++    case GRUB_INSTALL_PLATFORM_SW64_EFI:
+       break;
+ 
+     case GRUB_INSTALL_PLATFORM_I386_QEMU:
+@@ -1113,6 +1117,7 @@ main (int argc, char *argv[])
+     case GRUB_INSTALL_PLATFORM_I386_XEN:
+     case GRUB_INSTALL_PLATFORM_X86_64_XEN:
+     case GRUB_INSTALL_PLATFORM_I386_XEN_PVH:
++    case GRUB_INSTALL_PLATFORM_SW64_EFI:
+       free (install_device);
+       install_device = NULL;
+       break;
+@@ -1158,6 +1163,7 @@ main (int argc, char *argv[])
+     case GRUB_INSTALL_PLATFORM_RISCV64_EFI:
+     case GRUB_INSTALL_PLATFORM_MIPS64EL_EFI:
+     case GRUB_INSTALL_PLATFORM_IA64_EFI:
++    case GRUB_INSTALL_PLATFORM_SW64_EFI:
+       is_efi = 1;
+       break;
+     default:
+@@ -1310,6 +1316,9 @@ main (int argc, char *argv[])
+ 	  efi_suffix = "mips";
+ 	  efi_suffix_upper = "MIPS";
+ 	  break;
++	case GRUB_INSTALL_PLATFORM_SW64_EFI:
++	  efi_suffix = "sw64";
++	  efi_suffix_upper = "SW64";
+ 	default:
+ 	  break;
+ 	}
+@@ -1689,6 +1698,7 @@ main (int argc, char *argv[])
+ 		  case GRUB_INSTALL_PLATFORM_RISCV64_EFI:
+ 		  case GRUB_INSTALL_PLATFORM_MIPS64EL_EFI:
+ 		  case GRUB_INSTALL_PLATFORM_IA64_EFI:
++		  case GRUB_INSTALL_PLATFORM_SW64_EFI:
+ 		    g = grub_util_guess_efi_drive (*curdev);
+ 		    break;
+ 		  case GRUB_INSTALL_PLATFORM_SPARC64_IEEE1275:
+@@ -1786,6 +1796,7 @@ main (int argc, char *argv[])
+     case GRUB_INSTALL_PLATFORM_RISCV64_EFI:
+     case GRUB_INSTALL_PLATFORM_MIPS64EL_EFI:
+     case GRUB_INSTALL_PLATFORM_IA64_EFI:
++    case GRUB_INSTALL_PLATFORM_SW64_EFI:
+       core_name = "core.efi";
+       snprintf (mkimage_target, sizeof (mkimage_target),
+ 		"%s-%s",
+@@ -1911,6 +1922,7 @@ main (int argc, char *argv[])
+     case GRUB_INSTALL_PLATFORM_I386_XEN:
+     case GRUB_INSTALL_PLATFORM_X86_64_XEN:
+     case GRUB_INSTALL_PLATFORM_I386_XEN_PVH:
++    case GRUB_INSTALL_PLATFORM_SW64_EFI:
+       break;
+       /* pacify warning.  */
+     case GRUB_INSTALL_PLATFORM_MAX:
+@@ -2167,6 +2179,7 @@ main (int argc, char *argv[])
+     case GRUB_INSTALL_PLATFORM_RISCV64_EFI:
+     case GRUB_INSTALL_PLATFORM_MIPS64EL_EFI:
+     case GRUB_INSTALL_PLATFORM_IA64_EFI:
++    case GRUB_INSTALL_PLATFORM_SW64_EFI:
+       {
+ 	char *dst = grub_util_path_concat (2, efidir, efi_file);
+ 	char *removable_file = xasprintf ("BOOT%s.EFI", efi_suffix_upper);
+diff --git a/util/grub-mknetdir.c b/util/grub-mknetdir.c
+index f4f6795..17e641d 100644
+--- a/util/grub-mknetdir.c
++++ b/util/grub-mknetdir.c
+@@ -111,6 +111,7 @@ static struct
+     [GRUB_INSTALL_PLATFORM_RISCV32_EFI] = { "riscv32-efi", "efinet", ".efi" },
+     [GRUB_INSTALL_PLATFORM_RISCV64_EFI] = { "riscv64-efi", "efinet", ".efi" },
+     [GRUB_INSTALL_PLATFORM_MIPS64EL_EFI] = { "mips64el-efi", "efinet", ".efi" },
++    [GRUB_INSTALL_PLATFORM_SW64_EFI] = { "sw64-efi", "efinet", ".efi" },
+   };
+ 
+ static void
+diff --git a/util/grub-mkrescue.c b/util/grub-mkrescue.c
+index 8ca22e9..18b9c4c 100644
+--- a/util/grub-mkrescue.c
++++ b/util/grub-mkrescue.c
+@@ -565,7 +565,8 @@ main (int argc, char *argv[])
+ 	  || source_dirs[GRUB_INSTALL_PLATFORM_RISCV32_EFI]
+ 	  || source_dirs[GRUB_INSTALL_PLATFORM_RISCV64_EFI]
+ 	  || source_dirs[GRUB_INSTALL_PLATFORM_MIPS64EL_EFI]
+-	  || source_dirs[GRUB_INSTALL_PLATFORM_X86_64_EFI])
++	  || source_dirs[GRUB_INSTALL_PLATFORM_X86_64_EFI]
++	  || source_dirs[GRUB_INSTALL_PLATFORM_SW64_EFI])
+ 	system_area = SYS_AREA_COMMON;
+       else if (source_dirs[GRUB_INSTALL_PLATFORM_SPARC64_IEEE1275])
+ 	system_area = SYS_AREA_SPARC;
+@@ -766,7 +767,8 @@ main (int argc, char *argv[])
+       || source_dirs[GRUB_INSTALL_PLATFORM_LOONGARCH64_EFI]
+       || source_dirs[GRUB_INSTALL_PLATFORM_MIPS64EL_EFI]
+       || source_dirs[GRUB_INSTALL_PLATFORM_RISCV32_EFI]
+-      || source_dirs[GRUB_INSTALL_PLATFORM_RISCV64_EFI])
++      || source_dirs[GRUB_INSTALL_PLATFORM_RISCV64_EFI]
++      || source_dirs[GRUB_INSTALL_PLATFORM_SW64_EFI])
+     {
+       FILE *f;
+       char *efidir_efi = grub_util_path_concat (2, iso9660_dir, "EFI");
+@@ -828,6 +830,10 @@ main (int argc, char *argv[])
+       make_image_abs (GRUB_INSTALL_PLATFORM_RISCV64_EFI, "riscv64-efi", imgname);
+       free (imgname);
+ 
++      imgname = grub_util_path_concat (2, efidir_efi_boot, "bootsw64.efi");
++      make_image_fwdisk_abs (GRUB_INSTALL_PLATFORM_SW64_EFI, "sw64-efi", imgname);
++      free (imgname);
++
+       imgname = grub_util_path_concat (2, efidir_efi_boot, "bootmips64el.efi");
+       make_image_abs (GRUB_INSTALL_PLATFORM_MIPS64EL_EFI, "mips64el-efi", imgname);
+       free (imgname);
+diff --git a/util/mkimage.c b/util/mkimage.c
+index c56d2fd..e2d9561 100644
+--- a/util/mkimage.c
++++ b/util/mkimage.c
+@@ -425,6 +425,22 @@ static const struct grub_install_image_target_desc image_targets[] =
+       .pe_target = GRUB_PE32_MACHINE_IA64,
+       .elf_target = EM_IA_64,
+     },
++    {
++      .dirname = "sw64-efi",
++      .names = {"sw64-efi", NULL},
++      .voidp_sizeof = 8,
++      .bigendian = 0,
++      .id = IMAGE_EFI,
++      .flags = PLATFORM_FLAGS_NONE,
++      .total_module_size = TARGET_NO_FIELD,
++      .decompressor_compressed_size = TARGET_NO_FIELD,
++      .decompressor_uncompressed_size = TARGET_NO_FIELD,
++      .decompressor_uncompressed_addr = TARGET_NO_FIELD,
++      .section_align = GRUB_PE32_SECTION_ALIGNMENT,
++      .vaddr_offset = EFI64_HEADER_SIZE,
++      .pe_target = GRUB_PE32_MACHINE_SW_64,
++      .elf_target = EM_SW_64,
++    },
+     {
+       .dirname = "mips-arc",
+       .names = {"mips-arc", NULL},
+-- 
+2.20.1
+

--- a/debian/patches/sw64/0006-sw64-drop-all-efi_call-wrappers.patch
+++ b/debian/patches/sw64/0006-sw64-drop-all-efi_call-wrappers.patch
@@ -1,0 +1,26 @@
+
+--- grub2-2.12.orig/grub-core/kern/sw64/efi/init.c
++++ grub2-2.12/grub-core/kern/sw64/efi/init.c
+@@ -57,9 +57,9 @@ grub_machine_init (void)
+ 
+   b = grub_efi_system_table->boot_services;
+ 
+-  efi_call_5 (b->create_event, GRUB_EFI_EVT_TIMER | GRUB_EFI_EVT_NOTIFY_SIGNAL,
++  b->create_event (GRUB_EFI_EVT_TIMER | GRUB_EFI_EVT_NOTIFY_SIGNAL,
+ 	      GRUB_EFI_TPL_CALLBACK, increment_timer, NULL, &tmr_evt);
+-  efi_call_3 (b->set_timer, tmr_evt, GRUB_EFI_TIMER_PERIODIC, 100000);
++  b->set_timer (tmr_evt, GRUB_EFI_TIMER_PERIODIC, 100000);
+ 
+   grub_print_info ();
+   grub_install_get_time_ms (grub_efi_get_time_ms);
+@@ -75,8 +75,8 @@ grub_machine_fini (int flags)
+ 
+   b = grub_efi_system_table->boot_services;
+ 
+-  efi_call_3 (b->set_timer, tmr_evt, GRUB_EFI_TIMER_CANCEL, 0);
+-  efi_call_1 (b->close_event, tmr_evt);
++  b->set_timer (tmr_evt, GRUB_EFI_TIMER_CANCEL, 0);
++  b->close_event (tmr_evt);
+ 
+   grub_efi_fini ();
+ 

--- a/debian/patches/sw64/0007-sw64-fix-efi-and-peimage-build-issues.patch
+++ b/debian/patches/sw64/0007-sw64-fix-efi-and-peimage-build-issues.patch
@@ -1,0 +1,12 @@
+diff --git a/grub-core/loader/efi/peimage.c b/grub-core/loader/efi/peimage.c
+index xxxxxxx..xxxxxxx 100644
+--- a/grub-core/loader/efi/peimage.c
++++ b/grub-core/loader/efi/peimage.c
+@@ -63,6 +67,8 @@ static grub_uint16_t machines[] = {
+   GRUB_PE32_MACHINE_RISCV64,
+ #elif defined(__loongarch__) && __loongarch_grlen == 64
+   GRUB_PE32_MACHINE_LOONGARCH64,
++#elif defined(__sw_64__)
++  GRUB_PE32_MACHINE_SW_64,
+ #endif
+ };

--- a/debian/rules
+++ b/debian/rules
@@ -65,7 +65,7 @@ BUILD_PACKAGES := $(strip $(shell dh_listpackages))
 # REAL_PACKAGES build an actual grub variant (and therefore have both configure
 # and build stages). EXTRA_PACKAGES do not build grub but may depend on a
 # REAL_PACKAGE (and therefore only have a build stage)
-REAL_PACKAGES = grub-common grub-emu grub-pc grub-coreboot grub-efi-ia32 grub-efi-amd64 grub-efi-ia64 grub-efi-arm grub-efi-arm64 grub-efi-riscv64 grub-efi-loong64 grub-efi-mips64el grub-ieee1275 grub-firmware-qemu grub-uboot grub-xen grub-yeeloong
+REAL_PACKAGES = grub-common grub-emu grub-pc grub-coreboot grub-efi-ia32 grub-efi-amd64 grub-efi-ia64 grub-efi-arm grub-efi-arm64 grub-efi-riscv64 grub-efi-loong64 grub-efi-mips64el grub-efi-sw64 grub-ieee1275 grub-firmware-qemu grub-uboot grub-xen grub-yeeloong
 EXTRA_PACKAGES = grub-rescue-pc grub-xen-host
 
 ifneq (,$(filter i386 amd64,$(DEB_HOST_ARCH_CPU)))
@@ -86,6 +86,8 @@ else ifeq (loong64,$(DEB_HOST_ARCH_CPU))
 COMMON_PLATFORM := efi-loong64
 else ifeq (mips64el,$(DEB_HOST_ARCH_CPU))
 COMMON_PLATFORM := efi-mips64el
+else ifeq (sw64,$(DEB_HOST_ARCH_CPU))
+COMMON_PLATFORM := efi-sw64
 else
 COMMON_PLATFORM := none
 BUILD_PACKAGES += grub-none
@@ -101,6 +103,8 @@ FLICKER_FREE_BOOT := no
 else ifeq ($(DEB_HOST_ARCH_CPU),loong64)
 FLICKER_FREE_BOOT := no
 else ifeq ($(DEB_HOST_ARCH_CPU),mips64el)
+FLICKER_FREE_BOOT := no
+else ifeq ($(DEB_HOST_ARCH_CPU),sw64)
 FLICKER_FREE_BOOT := no
 else
 FLICKER_FREE_BOOT := yes
@@ -147,6 +151,8 @@ debian/stamps/build-grub-efi-loong64 install/grub-efi-loong64: export SB_PLATFOR
 debian/stamps/build-grub-efi-loong64 install/grub-efi-loong64: export SB_EFI_NAME := loongarch64
 debian/stamps/build-grub-efi-riscv64 install/grub-efi-riscv64: export SB_PLATFORM := riscv64-efi
 debian/stamps/build-grub-efi-riscv64 install/grub-efi-riscv64: export SB_EFI_NAME := riscv64
+debian/stamps/build-grub-efi-sw64 install/grub-efi-sw64: export SB_PLATFORM := sw64-efi
+debian/stamps/build-grub-efi-sw64 install/grub-efi-sw64: export SB_EFI_NAME := sw64
 SB_PACKAGE :=
 ifeq (yes,$(shell dpkg-vendor --derives-from Ubuntu && echo yes))
 ifeq ($(DEB_HOST_ARCH),amd64)
@@ -231,7 +237,7 @@ debian/stamps/configure-grub-efi-amd64:
 	mkdir -p debian/stamps $(subst debian/stamps/configure-,obj/,$@)
 	dh_auto_configure -- $(confflags) --with-platform=efi --target=amd64-pe --program-prefix=""
 	touch $@
-debian/stamps/configure-grub-efi-ia64 debian/stamps/configure-grub-efi-arm debian/stamps/configure-grub-efi-arm64 debian/stamps/configure-grub-efi-riscv64 debian/stamps/configure-grub-efi-loong64 debian/stamps/configure-grub-efi-mips64el:
+debian/stamps/configure-grub-efi-ia64 debian/stamps/configure-grub-efi-arm debian/stamps/configure-grub-efi-arm64 debian/stamps/configure-grub-efi-riscv64 debian/stamps/configure-grub-efi-loong64 debian/stamps/configure-grub-efi-mips64el debian/stamps/configure-grub-efi-sw64:
 	mkdir -p debian/stamps $(subst debian/stamps/configure-,obj/,$@)
 	dh_auto_configure -- $(confflags) --with-platform=efi
 	touch $@
@@ -252,11 +258,11 @@ debian/stamps/configure-grub-firmware-qemu:
 	dh_auto_configure -- $(confflags) --with-platform=qemu
 	touch $@
 
-debian/stamps/build-grub-none debian/stamps/build-grub-efi-ia64 debian/stamps/build-grub-efi-arm debian/stamps/build-grub-efi-riscv64 debian/stamps/build-grub-efi-loong64 debian/stamps/build-grub-efi-mips64el debian/stamps/build-grub-coreboot debian/stamps/build-grub-emu debian/stamps/build-grub-uboot debian/stamps/build-grub-xen-i386 debian/stamps/build-grub-xen-amd64 debian/stamps/build-grub-xen-pvh-i386 debian/stamps/build-grub-yeeloong: debian/stamps/build-%: debian/stamps/configure-%
+debian/stamps/build-grub-none debian/stamps/build-grub-efi-ia64 debian/stamps/build-grub-efi-arm debian/stamps/build-grub-efi-riscv64 debian/stamps/build-grub-efi-loong64 debian/stamps/build-grub-efi-mips64el debian/stamps/build-grub-efi-sw64 debian/stamps/build-grub-coreboot debian/stamps/build-grub-emu debian/stamps/build-grub-uboot debian/stamps/build-grub-xen-i386 debian/stamps/build-grub-xen-amd64 debian/stamps/build-grub-xen-pvh-i386 debian/stamps/build-grub-yeeloong: debian/stamps/build-%: debian/stamps/configure-%
 	dh_auto_build
 	touch $@
 
-debian/stamps/build-grub-efi-ia32 debian/stamps/build-grub-efi-ia64 debian/stamps/build-grub-efi-arm debian/stamps/build-grub-efi-loong64 debian/stamps/build-grub-efi-amd64 debian/stamps/build-grub-efi-arm64 debian/stamps/build-grub-efi-riscv64: debian/stamps/build-%: debian/stamps/configure-% debian/stamps/build-grub-$(COMMON_PLATFORM)
+debian/stamps/build-grub-efi-ia32 debian/stamps/build-grub-efi-ia64 debian/stamps/build-grub-efi-arm debian/stamps/build-grub-efi-loong64 debian/stamps/build-grub-efi-amd64 debian/stamps/build-grub-efi-arm64 debian/stamps/build-grub-efi-riscv64 debian/stamps/build-grub-efi-sw64: debian/stamps/build-%: debian/stamps/configure-% debian/stamps/build-grub-$(COMMON_PLATFORM)
 	dh_auto_build
 	grub_dir=`mktemp -d` ; \
 	sed -e "s/@DEB_VERSION@/$(deb_version)/g" \
@@ -393,7 +399,7 @@ install/grub-none:
 	# files.
 	mkdir -p debian/tmp-$(package)/usr/share/locale
 
-install/grub-pc install/grub-efi-ia32 install/grub-efi-amd64 install/grub-efi-ia64 install/grub-efi-arm install/grub-efi-arm64 install/grub-efi-riscv64 install/grub-efi-loong64 install/grub-efi-mips64el install/grub-ieee1275 install/grub-coreboot install/grub-emu install/grub-uboot install/grub-xen install/grub-yeeloong:
+install/grub-pc install/grub-efi-ia32 install/grub-efi-amd64 install/grub-efi-ia64 install/grub-efi-arm install/grub-efi-arm64 install/grub-efi-riscv64 install/grub-efi-loong64 install/grub-efi-mips64el install/grub-efi-sw64 install/grub-ieee1275 install/grub-coreboot install/grub-emu install/grub-uboot install/grub-xen install/grub-yeeloong:
 	set -e ; \
 	if [ "$@" = "install/grub-xen" ] ; then \
 		dh_auto_install -Bobj/grub-xen-i386 --destdir=debian/tmp-$(package); \
@@ -539,7 +545,7 @@ endif
 
 NON_PLATFORM_PACKAGES = $(filter grub2 grub-linuxbios grub-efi grub-rescue-pc grub-firmware-qemu grub-xen-host,$(BUILD_PACKAGES))
 COMMON_PLATFORM_PACKAGES = $(filter grub-common grub2-common grub-theme-starfield grub-mount-udeb,$(BUILD_PACKAGES))
-PLATFORM_PACKAGES = $(filter grub-pc grub-efi-ia32 grub-efi-amd64 grub-efi-ia64 grub-efi-arm grub-efi-arm64 grub-efi-riscv64 grub-efi-loong64 grub-efi-mips64el grub-ieee1275 grub-coreboot grub-uboot grub-xen grub-yeeloong,$(BUILD_PACKAGES))
+PLATFORM_PACKAGES = $(filter grub-pc grub-efi-ia32 grub-efi-amd64 grub-efi-ia64 grub-efi-arm grub-efi-arm64 grub-efi-riscv64 grub-efi-loong64 grub-efi-mips64el grub-efi-sw64 grub-ieee1275 grub-coreboot grub-uboot grub-xen grub-yeeloong,$(BUILD_PACKAGES))
 
 override_dh_install:
 ifneq (,$(NON_PLATFORM_PACKAGES))


### PR DESCRIPTION
## Summary by Sourcery

Add Debian packaging support for the SW64 architecture by wiring new SW64-specific patches into the build.

New Features:
- Introduce SW64-specific early startup, Linux load logic, relocation handling, and auxiliary files via architecture patches.

Build:
- Update Debian control, rules, changelog, and patch series to build packages with SW64 architecture support.