### PR TITLE
fix(templates):  Use findfs for UUID/PARTUUID device lookup

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+grub2 (2.12-7deepin15) unstable; urgency=medium
+
+  * Backport upstream fix from grub2:
+  * 26f82dc6: templates: Use findfs for UUID/PARTUUID device lookup
+
+ -- jiabowen <jiabowen@uniontech.com>  Thu, 28 May 2026 14:35:19 +0800
+
 grub2 (2.12-7deepin14) unstable; urgency=medium
 
   * fix(sw64): fix EFI call compatibility and PE machine detection

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -229,3 +229,4 @@ use-time-register-in-grub_efi_get_time_ms.patch
 deepin/0006-grub-install-support-secureboot-detect-for-loongarch.patch
 uniontech-mkconfig_lib-suppress-stderr-for-grub-probe-in-uses_abstraction.patch
 uniontech-update-zh-cn-translate.patch
+templates-26f82dc6.patch

--- a/debian/patches/templates-26f82dc6.patch
+++ b/debian/patches/templates-26f82dc6.patch
@@ -1,0 +1,41 @@
+From 26f82dc615c8eedaa4d9fc2c5ba9732dc81fa13d Mon Sep 17 00:00:00 2001
+From: Egor Ignatov <egori@altlinux.org>
+Date: Tue, 17 Mar 2026 11:14:04 +0500
+Subject: [PATCH] templates: Use findfs for UUID/PARTUUID device lookup
+
+Replace test -e checks against /dev/disk/by-uuid and /dev/disk/by-partuuid
+symlinks with findfs, which uses libblkid and /sys/block scanning to resolve
+devices even when udev symlinks are missing.
+
+Signed-off-by: Egor Ignatov <egori@altlinux.org>
+
+Index: 26f82dc6/util/grub.d/10_linux.in
+===================================================================
+--- 26f82dc6.orig/util/grub.d/10_linux.in
++++ 26f82dc6/util/grub.d/10_linux.in
+@@ -75,8 +75,8 @@ fi
+ if ( [ "x${GRUB_DEVICE_UUID}" = "x" ] && [ "x${GRUB_DEVICE_PARTUUID}" = "x" ] ) \
+     || ( [ "x${GRUB_DISABLE_LINUX_UUID}" = "xtrue" ] \
+ 	&& [ "x${GRUB_DISABLE_LINUX_PARTUUID}" = "xtrue" ] ) \
+-    || ( ! test -e "/dev/disk/by-uuid/${GRUB_DEVICE_UUID}" \
+-	&& ! test -e "/dev/disk/by-partuuid/${GRUB_DEVICE_PARTUUID}" ) \
++    || ( ! findfs UUID="${GRUB_DEVICE_UUID}" > /dev/null 2>&1 \
++	&& ! findfs PARTUUID="${GRUB_DEVICE_PARTUUID}" > /dev/null 2>&1 ) \
+     || ( test -e "${GRUB_DEVICE}" && uses_abstraction "${GRUB_DEVICE}" lvm ); then
+   LINUX_ROOT_DEVICE=${GRUB_DEVICE}
+ elif [ "x${GRUB_DEVICE_UUID}" = "x" ] \
+Index: 26f82dc6/util/grub.d/20_linux_xen.in
+===================================================================
+--- 26f82dc6.orig/util/grub.d/20_linux_xen.in
++++ 26f82dc6/util/grub.d/20_linux_xen.in
+@@ -59,8 +59,8 @@ esac
+ if ( [ "x${GRUB_DEVICE_UUID}" = "x" ] && [ "x${GRUB_DEVICE_PARTUUID}" = "x" ] ) \
+     || ( [ "x${GRUB_DISABLE_LINUX_UUID}" = "xtrue" ] \
+ 	&& [ "x${GRUB_DISABLE_LINUX_PARTUUID}" = "xtrue" ] ) \
+-    || ( ! test -e "/dev/disk/by-uuid/${GRUB_DEVICE_UUID}" \
+-	&& ! test -e "/dev/disk/by-partuuid/${GRUB_DEVICE_PARTUUID}" ) \
++    || ( ! findfs UUID="${GRUB_DEVICE_UUID}" > /dev/null 2>&1 \
++	&& ! findfs PARTUUID="${GRUB_DEVICE_PARTUUID}" > /dev/null 2>&1 ) \
+     || ( test -e "${GRUB_DEVICE}" && uses_abstraction "${GRUB_DEVICE}" lvm ); then
+   LINUX_ROOT_DEVICE=${GRUB_DEVICE}
+ elif [ "x${GRUB_DEVICE_UUID}" = "x" ] \


### PR DESCRIPTION
Backport critical fix from upstream gnu-grub/grub.

## Patch

- **templates**:  Use findfs for UUID/PARTUUID device lookup
  Upstream: [gnu-grub/grub@17f757c6](https://gitlab.freedesktop.org/gnu-grub/grub/-/commit/26f82dc615c8eedaa4d9fc2c5ba9732dc81fa13d)

## Test Plan

- quilt push -a succeeds cleanly (Debian only)
- dpkg-buildpackage builds successfully (Debian only)