### PR TITLE
fix(disk-efi-efidisk):  Fix memory leak

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+grub2 (2.12-7deepin15) unstable; urgency=medium
+
+  * Backport upstream fix from grub2:
+  * dd6cb6de: disk/efi/efidisk: Fix memory leak
+
+ -- jiabowen <jiabowen@uniontech.com>  Thu, 28 May 2026 14:35:44 +0800
+
 grub2 (2.12-7deepin14) unstable; urgency=medium
 
   * fix(sw64): fix EFI call compatibility and PE machine detection

--- a/debian/patches/disk-efi-efidisk-dd6cb6de.patch
+++ b/debian/patches/disk-efi-efidisk-dd6cb6de.patch
@@ -1,0 +1,35 @@
+From dd6cb6deb91402e37f755aa3f79056f5665cf2f9 Mon Sep 17 00:00:00 2001
+From: khaalid cali <khaliidcaliy@gmail.com>
+Date: Tue, 20 May 2025 17:42:05 +0000
+Subject: [PATCH] disk/efi/efidisk: Fix memory leak
+
+Free "dp" in case of failure.
+
+Signed-off-by: Khalid Ali <khaliidcaliy@gmail.com>
+
+Index: dd6cb6de/grub-core/disk/efi/efidisk.c
+===================================================================
+--- dd6cb6de.orig/grub-core/disk/efi/efidisk.c
++++ dd6cb6de/grub-core/disk/efi/efidisk.c
+@@ -130,7 +130,10 @@ find_parent_device (struct grub_efidisk_
+ 
+   ldp = grub_efi_find_last_device_path (dp);
+   if (! ldp)
++  {
++    grub_free (dp);
+     return 0;
++  }
+ 
+   ldp->type = GRUB_EFI_END_DEVICE_PATH_TYPE;
+   ldp->subtype = GRUB_EFI_END_ENTIRE_DEVICE_PATH_SUBTYPE;
+@@ -163,7 +166,10 @@ is_child (struct grub_efidisk_data *chil
+ 
+   ldp = grub_efi_find_last_device_path (dp);
+   if (! ldp)
++  {
++    grub_free (dp);
+     return 0;
++  }
+ 
+   ldp->type = GRUB_EFI_END_DEVICE_PATH_TYPE;
+   ldp->subtype = GRUB_EFI_END_ENTIRE_DEVICE_PATH_SUBTYPE;

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -229,3 +229,4 @@ use-time-register-in-grub_efi_get_time_ms.patch
 deepin/0006-grub-install-support-secureboot-detect-for-loongarch.patch
 uniontech-mkconfig_lib-suppress-stderr-for-grub-probe-in-uses_abstraction.patch
 uniontech-update-zh-cn-translate.patch
+disk-efi-efidisk-dd6cb6de.patch


### PR DESCRIPTION
Backport critical fix from upstream gnu-grub/grub.

## Patch

- **disk-efi-efidisk**:  Fix memory leak
  Upstream: [gnu-grub/grub@ea728a29](https://gitlab.freedesktop.org/gnu-grub/grub/-/commit/dd6cb6deb91402e37f755aa3f79056f5665cf2f9)

## Test Plan

- quilt push -a succeeds cleanly (Debian only)
- dpkg-buildpackage builds successfully (Debian only)