### PR TITLE
fix(util-config):  Fix memory leak in grub_util_parse_config

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+grub2 (2.12-7deepin15) unstable; urgency=medium
+
+  * Backport upstream fix from grub2:
+  * 7115cf2a: util/config: Fix memory leak in grub_util_parse_config
+
+ -- jiabowen <jiabowen@uniontech.com>  Thu, 28 May 2026 14:35:45 +0800
+
 grub2 (2.12-7deepin14) unstable; urgency=medium
 
   * fix(sw64): fix EFI call compatibility and PE machine detection

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -229,3 +229,4 @@ use-time-register-in-grub_efi_get_time_ms.patch
 deepin/0006-grub-install-support-secureboot-detect-for-loongarch.patch
 uniontech-mkconfig_lib-suppress-stderr-for-grub-probe-in-uses_abstraction.patch
 uniontech-update-zh-cn-translate.patch
+util-config-7115cf2a.patch

--- a/debian/patches/util-config-7115cf2a.patch
+++ b/debian/patches/util-config-7115cf2a.patch
@@ -1,0 +1,25 @@
+From 7115cf2ad9124add0294b9fcd72a9cc30cd9f3cb Mon Sep 17 00:00:00 2001
+From: Srish Srinivasan <ssrish@linux.ibm.com>
+Date: Fri, 27 Mar 2026 12:19:44 +0530
+Subject: [PATCH] util/config: Fix memory leak in grub_util_parse_config
+
+In grub_util_parse_config(), "buffer" is set to NULL before the call
+to getline(). So, getline() will allocate memory for "buffer". But,
+grub_util_parse_config() does not free "buffer" before returning.
+This results in a memory leak.
+
+Free "buffer" before returning to fix this problem.
+
+Signed-off-by: Srish Srinivasan <ssrish@linux.ibm.com>
+
+Index: 7115cf2a/util/config.c
+===================================================================
+--- 7115cf2a.orig/util/config.c
++++ 7115cf2a/util/config.c
+@@ -117,5 +117,6 @@ grub_util_parse_config (FILE *f, struct
+ 	  *optr = '\0';
+ 	}
+     }
++  free (buffer);
+ }
+ 


### PR DESCRIPTION
Backport critical fix from upstream gnu-grub/grub.

## Patch

- **util-config**:  Fix memory leak in grub_util_parse_config
  Upstream: [gnu-grub/grub@8e613cb3](https://gitlab.freedesktop.org/gnu-grub/grub/-/commit/7115cf2ad9124add0294b9fcd72a9cc30cd9f3cb)

## Test Plan

- quilt push -a succeeds cleanly (Debian only)
- dpkg-buildpackage builds successfully (Debian only)