### PR TITLE
fix(commands-pgp):  fix memory leaks in grub_verify_signature

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+grub2 (2.12-7deepin15) unstable; urgency=medium
+
+  * Backport upstream fix from grub2:
+  * 52f113a8: commands/pgp: fix memory leaks in grub_verify_signature
+
+ -- jiabowen <jiabowen@uniontech.com>  Thu, 28 May 2026 14:35:47 +0800
+
 grub2 (2.12-7deepin14) unstable; urgency=medium
 
   * fix(sw64): fix EFI call compatibility and PE machine detection

--- a/debian/patches/commands-pgp-52f113a8.patch
+++ b/debian/patches/commands-pgp-52f113a8.patch
@@ -1,0 +1,28 @@
+From 52f113a86ebb0dde872e9cc7a11e667edb623a37 Mon Sep 17 00:00:00 2001
+From: Deividas Puplauskas <deividas.puplauskas@gmail.com>
+Date: Fri, 3 Apr 2026 23:46:32 +0200
+Subject: [PATCH] commands/pgp: fix memory leaks in grub_verify_signature
+
+Free readbuf in both the success path and fail path.
+
+Signed-off-by: Deividas Puplauskas <deividas.puplauskas@gmail.com>
+
+Index: 52f113a8/grub-core/commands/pgp.c
+===================================================================
+--- 52f113a8.orig/grub-core/commands/pgp.c
++++ 52f113a8/grub-core/commands/pgp.c
+@@ -718,11 +718,13 @@ grub_verify_signature (grub_file_t f, co
+ 	break;
+       err = grub_pubkey_write (&ctxt, readbuf, r);
+       if (err)
+-	return err;
++	goto fail;
+     }
+ 
+   grub_verify_signature_real (&ctxt, pkey);
+  fail:
++  if (readbuf)
++    grub_free(readbuf);
+   grub_pubkey_close_real (&ctxt);
+   return grub_errno;
+ }

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -229,3 +229,4 @@ use-time-register-in-grub_efi_get_time_ms.patch
 deepin/0006-grub-install-support-secureboot-detect-for-loongarch.patch
 uniontech-mkconfig_lib-suppress-stderr-for-grub-probe-in-uses_abstraction.patch
 uniontech-update-zh-cn-translate.patch
+commands-pgp-52f113a8.patch


### PR DESCRIPTION
Backport critical fix from upstream gnu-grub/grub.

## Patch

- **commands-pgp**:  fix memory leaks in grub_verify_signature
  Upstream: [gnu-grub/grub@63804623](https://gitlab.freedesktop.org/gnu-grub/grub/-/commit/52f113a86ebb0dde872e9cc7a11e667edb623a37)

## Test Plan

- quilt push -a succeeds cleanly (Debian only)
- dpkg-buildpackage builds successfully (Debian only)