### PR TITLE
fix(grub-core-disk-usbms-c-grub-usbms-attach):  reuse free slots

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+grub2 (2.12-7deepin15) unstable; urgency=medium
+
+  * Backport upstream fix from grub2:
+  * 00f8ad96: grub-core/disk/usbms.c (grub_usbms_attach): reuse free
+    slots
+
+ -- jiabowen <jiabowen@uniontech.com>  Thu, 28 May 2026 14:35:51 +0800
+
 grub2 (2.12-7deepin14) unstable; urgency=medium
 
   * fix(sw64): fix EFI call compatibility and PE machine detection

--- a/debian/patches/grub-core-disk-usbms-c-grub-usbms-attach-00f8ad96.patch
+++ b/debian/patches/grub-core-disk-usbms-c-grub-usbms-attach-00f8ad96.patch
@@ -1,0 +1,42 @@
+From 00f8ad96c7c2c3ff42a6cfee3f7257d00c1795d6 Mon Sep 17 00:00:00 2001
+From: Deividas Puplauskas <deividas.puplauskas@gmail.com>
+Date: Mon, 30 Mar 2026 20:23:10 +0200
+Subject: [PATCH] grub-core/disk/usbms.c (grub_usbms_attach): reuse free slots
+
+Reuse free slots from grub_usbms_devices array for attaching new
+USB mass storage devices. Same loop logic is already used in
+grub_usbms_detach.
+
+Signed-off-by: Deividas Puplauskas <deividas.puplauskas@gmail.com>
+
+Index: 00f8ad96/grub-core/disk/usbms.c
+===================================================================
+--- 00f8ad96.orig/grub-core/disk/usbms.c
++++ 00f8ad96/grub-core/disk/usbms.c
+@@ -74,7 +74,6 @@ typedef struct grub_usbms_dev *grub_usbm
+ /* FIXME: remove limit.  */
+ #define MAX_USBMS_DEVICES 128
+ static grub_usbms_dev_t grub_usbms_devices[MAX_USBMS_DEVICES];
+-static int first_available_slot = 0;
+ 
+ static grub_usb_err_t
+ grub_usbms_cbi_cmd (grub_usb_device_t dev, int interface,
+@@ -149,11 +148,14 @@ grub_usbms_attach (grub_usb_device_t usb
+ 
+   grub_boot_time ("Attaching USB mass storage");
+ 
+-  if (first_available_slot == ARRAY_SIZE (grub_usbms_devices))
+-    return 0;
++  for (curnum = 0; curnum < ARRAY_SIZE (grub_usbms_devices); curnum++)
++    {
++      if (!grub_usbms_devices[curnum])
++	break;
++    }
+ 
+-  curnum = first_available_slot;
+-  first_available_slot++;
++  if (curnum == ARRAY_SIZE (grub_usbms_devices))
++    return 0;
+ 
+   interf = usbdev->config[configno].interf[interfno].descif;
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -229,3 +229,4 @@ use-time-register-in-grub_efi_get_time_ms.patch
 deepin/0006-grub-install-support-secureboot-detect-for-loongarch.patch
 uniontech-mkconfig_lib-suppress-stderr-for-grub-probe-in-uses_abstraction.patch
 uniontech-update-zh-cn-translate.patch
+grub-core-disk-usbms-c-grub-usbms-attach-00f8ad96.patch


### PR DESCRIPTION
Backport critical fix from upstream gnu-grub/grub.

## Patch

- **grub-core-disk-usbms-c-grub-usbms-attach**:  reuse free slots
  Upstream: [gnu-grub/grub@6293b560](https://gitlab.freedesktop.org/gnu-grub/grub/-/commit/00f8ad96c7c2c3ff42a6cfee3f7257d00c1795d6)

## Test Plan

- quilt push -a succeeds cleanly (Debian only)
- dpkg-buildpackage builds successfully (Debian only)