### PR TITLE
fix(partition-number): Fix partition number calculation when no primary partitions exist

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+grub2 (2.12-7deepin15) unstable; urgency=medium
+
+  * Backport upstream fix from grub2:
+  * a4257251: Fix partition number calculation when no primary
+    partitions exist
+
+ -- jiabowen <jiabowen@uniontech.com>  Thu, 28 May 2026 14:37:24 +0800
+
 grub2 (2.12-7deepin14) unstable; urgency=medium
 
   * fix(sw64): fix EFI call compatibility and PE machine detection

--- a/debian/patches/partition-number-a4257251.patch
+++ b/debian/patches/partition-number-a4257251.patch
@@ -1,0 +1,25 @@
+From a4257251f4c31d22303c9a1e40c434cb98eb6969 Mon Sep 17 00:00:00 2001
+From: zeno <762013373@qq.com>
+Date: Mon, 6 Apr 2026 18:37:38 +0000
+Subject: [PATCH] Fix partition number calculation when no primary partitions
+ exist
+
+
+Index: a4257251/grub-core/partmap/msdos.c
+===================================================================
+--- a4257251.orig/grub-core/partmap/msdos.c
++++ a4257251/grub-core/partmap/msdos.c
+@@ -196,9 +196,10 @@ grub_partition_msdos_iterate (grub_disk_
+ 	      if (hook (disk, &p, hook_data))
+ 		return grub_errno;
+ 	    }
+-	  else if (p.number < 3)
+-	    /* If this partition is a logical one, shouldn't increase the
+-	       partition number.  */
++	  else if (! grub_msdos_partition_is_empty (e->type)
++	       && p.number < 3)
++	    /* If this partition is a primary one, increase the partition number.
++	       Do not increase for extended partitions or empty slots.  */
+ 	    p.number++;
+ 	}
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -229,3 +229,4 @@ use-time-register-in-grub_efi_get_time_ms.patch
 deepin/0006-grub-install-support-secureboot-detect-for-loongarch.patch
 uniontech-mkconfig_lib-suppress-stderr-for-grub-probe-in-uses_abstraction.patch
 uniontech-update-zh-cn-translate.patch
+partition-number-a4257251.patch


### PR DESCRIPTION
Backport critical fix from upstream gnu-grub/grub.

## Patch

- **partition-number**: Fix partition number calculation when no primary partitions exist
  Upstream: [gnu-grub/grub@f32e143c](https://gitlab.freedesktop.org/gnu-grub/grub/-/commit/a4257251f4c31d22303c9a1e40c434cb98eb6969)

## Test Plan

- quilt push -a succeeds cleanly (Debian only)
- dpkg-buildpackage builds successfully (Debian only)