### PR TITLE
fix(grub-mkstandalone):  warn on non-regular files

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+grub2 (2.12-7deepin15) unstable; urgency=medium
+
+  * Backport upstream fix from grub2:
+  * 7d3e803e: grub-mkstandalone: warn on non-regular files
+
+ -- jiabowen <jiabowen@uniontech.com>  Thu, 28 May 2026 14:39:27 +0800
+
 grub2 (2.12-7deepin14) unstable; urgency=medium
 
   * fix(sw64): fix EFI call compatibility and PE machine detection

--- a/debian/patches/grub-mkstandalone-7d3e803e.patch
+++ b/debian/patches/grub-mkstandalone-7d3e803e.patch
@@ -1,0 +1,40 @@
+From 7d3e803e310c0d723e18e5b6b577383663432843 Mon Sep 17 00:00:00 2001
+From: Philipp Schuster <philipp.schuster@cyberus-technology.de>
+Date: Wed, 29 Nov 2023 15:48:51 +0100
+Subject: [PATCH] grub-mkstandalone: warn on non-regular files
+
+grub-mkstandalone silently dropped non-regular files, which could
+cause unexpected omissions in standalone images. This commit:
+
+- Updates documentation to clarify that graft point targets must be
+  regular files.
+- Emits a warning when a non-regular file is skipped.
+
+Signed-off-by: Philipp Schuster <philipp.schuster@cyberus-technology.de>
+
+Index: 7d3e803e/util/grub-mkstandalone.c
+===================================================================
+--- 7d3e803e.orig/util/grub-mkstandalone.c
++++ 7d3e803e/util/grub-mkstandalone.c
+@@ -115,7 +115,7 @@ argp_parser (int key, char *arg, struct
+ 
+ struct argp argp = {
+   options, argp_parser, N_("[OPTION] SOURCE..."),
+-  N_("Generate a standalone image (containing all modules) in the selected format")"\v"N_("Graft point syntax (E.g. /boot/grub/grub.cfg=./grub.cfg) is accepted"),
++  N_("Generate a standalone image (containing all modules) in the selected format")"\v"N_("Graft point syntax (E.g. /boot/grub/grub.cfg=./grub.cfg) is accepted. The path on the right must point to a regular file."),
+   NULL, help_filter, NULL
+ };
+ 
+@@ -191,8 +191,10 @@ add_tar_file (const char *from,
+ 
+   COMPILE_TIME_ASSERT (sizeof (hd) == 512);
+ 
+-  if (grub_util_is_special_file (from))
+-    return;
++  if (grub_util_is_special_file (from)) {
++      grub_util_warn (_("skip: %s is not a regular file"), from);
++      return;
++  }
+ 
+   optr = tcn = xmalloc (strlen (to) + 1);
+   for (iptr = to; *iptr == '/'; iptr++);

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -229,3 +229,4 @@ use-time-register-in-grub_efi_get_time_ms.patch
 deepin/0006-grub-install-support-secureboot-detect-for-loongarch.patch
 uniontech-mkconfig_lib-suppress-stderr-for-grub-probe-in-uses_abstraction.patch
 uniontech-update-zh-cn-translate.patch
+grub-mkstandalone-7d3e803e.patch


### PR DESCRIPTION
Backport critical fix from upstream gnu-grub/grub.

## Patch

- **grub-mkstandalone**:  warn on non-regular files
  Upstream: [gnu-grub/grub@439b31bf](https://gitlab.freedesktop.org/gnu-grub/grub/-/commit/7d3e803e310c0d723e18e5b6b577383663432843)

## Test Plan

- quilt push -a succeeds cleanly (Debian only)
- dpkg-buildpackage builds successfully (Debian only)