### PR TITLE
fix(ia64):  Fix left shift overflow.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+grub2 (2.12-7deepin15) unstable; urgency=medium
+
+  * Backport upstream fix from grub2:
+  * 42889fea: ia64: Fix left shift overflow.
+
+ -- jiabowen <jiabowen@uniontech.com>  Thu, 28 May 2026 14:40:29 +0800
+
 grub2 (2.12-7deepin14) unstable; urgency=medium
 
   * fix(sw64): fix EFI call compatibility and PE machine detection

--- a/debian/patches/ia64-42889fea.patch
+++ b/debian/patches/ia64-42889fea.patch
@@ -1,0 +1,25 @@
+From 42889fea35c0e79ca9849951f8a9696ae0cb84b3 Mon Sep 17 00:00:00 2001
+From: Collin Funk <collin.funk1@gmail.com>
+Date: Sun, 4 May 2025 21:53:11 -0700
+Subject: [PATCH] ia64: Fix left shift overflow.
+
+* grub-core/kern/ia64/dl_helper.c (grub_ia64_set_immu64): Make constant
+unsigned.  This change was also done in Binutils, where this code
+originates from, in commit 108f6f97bd862e969f898c1347903ae1cf38ead4.
+
+Signed-off-by: Collin Funk <collin.funk1@gmail.com>
+Part-of: <https://gitlab.freedesktop.org/gnu-grub/grub/-/merge_requests/40>
+
+Index: 42889fea/grub-core/kern/ia64/dl_helper.c
+===================================================================
+--- 42889fea.orig/grub-core/kern/ia64/dl_helper.c
++++ 42889fea/grub-core/kern/ia64/dl_helper.c
+@@ -46,7 +46,7 @@ grub_ia64_set_immu64 (grub_addr_t addr,
+      slot 2: bits 23..63 in t1 */
+ 
+   /* First, clear the bits that form the 64 bit constant.  */
+-  t0 &= ~(0x3ffffLL << 46);
++  t0 &= ~(0x3ffffULL << 46);
+   t1 &= ~(0x7fffffLL
+ 	  | ((  (0x07fLL << 13) | (0x1ffLL << 27)
+ 		| (0x01fLL << 22) | (0x001LL << 21)

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -229,3 +229,4 @@ use-time-register-in-grub_efi_get_time_ms.patch
 deepin/0006-grub-install-support-secureboot-detect-for-loongarch.patch
 uniontech-mkconfig_lib-suppress-stderr-for-grub-probe-in-uses_abstraction.patch
 uniontech-update-zh-cn-translate.patch
+ia64-42889fea.patch


### PR DESCRIPTION
Backport critical fix from upstream gnu-grub/grub.

## Patch

- **ia64**:  Fix left shift overflow.
  Upstream: [gnu-grub/grub@3cd9db61](https://gitlab.freedesktop.org/gnu-grub/grub/-/commit/42889fea35c0e79ca9849951f8a9696ae0cb84b3)

## Test Plan

- quilt push -a succeeds cleanly (Debian only)
- dpkg-buildpackage builds successfully (Debian only)