### PR TITLE
fix(commands-pgp):  fix new-format packet length parsing.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+grub2 (2.12-7deepin15) unstable; urgency=medium
+
+  * Backport upstream fix from grub2:
+  * 5ee2e04d: commands/pgp: fix new-format packet length parsing.
+
+ -- jiabowen <jiabowen@uniontech.com>  Thu, 28 May 2026 14:40:55 +0800
+
 grub2 (2.12-7deepin14) unstable; urgency=medium
 
   * fix(sw64): fix EFI call compatibility and PE machine detection

--- a/debian/patches/commands-pgp-5ee2e04d.patch
+++ b/debian/patches/commands-pgp-5ee2e04d.patch
@@ -1,0 +1,52 @@
+From 5ee2e04db4ec48c049518f9bb5a126e66bd3d391 Mon Sep 17 00:00:00 2001
+From: Valtteri Vuorikoski <vuori@notcom.org>
+Date: Tue, 21 Apr 2026 22:26:18 +0300
+Subject: [PATCH] commands/pgp: fix new-format packet length parsing.
+
+Parsing of OpenPGP "new format" packet lengths is incorrect for the 2-octet
+format. The problem was originally reported in the Savannah ticket
+https://savannah.gnu.org/bugs/?68020. This applies the proposed fix and adds
+some explanatory comments because the length encoding is quite complicated.
+
+Sequoia-PGP produces the new format, while GnuPG produces the old format.
+
+Signed-off-by: Valtteri Vuorikoski <vuori@notcom.org>
+Reported-by: shoesoft <>
+Reviewed-by: Andrew Hamilton <adhamilt@gmail.com>
+Part-of: <https://gitlab.freedesktop.org/gnu-grub/grub/-/merge_requests/107>
+
+Index: 5ee2e04d/grub-core/commands/pgp.c
+===================================================================
+--- 5ee2e04d.orig/grub-core/commands/pgp.c
++++ 5ee2e04d/grub-core/commands/pgp.c
+@@ -79,7 +79,7 @@ read_packet_header (grub_file_t sig, gru
+ 
+   if (!(type & 0x80))
+     return grub_error (GRUB_ERR_BAD_SIGNATURE, N_("bad signature"));
+-  if (type & 0x40)
++  if (type & 0x40) /* Bit 6 set: new format packet length */
+     {
+       *out_type = (type & 0x3f);
+       if (grub_file_read (sig, &l, sizeof (l)) != 1)
+@@ -91,10 +91,11 @@ read_packet_header (grub_file_t sig, gru
+ 	}
+       if (l < 224)
+ 	{
++          /* RFC4880 2-octet length: ((b1 - 192) << 8) + (b2 + 192) */
+ 	  *len = (l - 192) << GRUB_CHAR_BIT;
+ 	  if (grub_file_read (sig, &l, sizeof (l)) != 1)
+ 	    return grub_error (GRUB_ERR_BAD_SIGNATURE, N_("bad signature"));
+-	  *len |= l;
++	  *len = (*len | l) + 192;
+ 	  return 0;
+ 	}
+       if (l == 255)
+@@ -106,6 +107,8 @@ read_packet_header (grub_file_t sig, gru
+ 	}
+       return grub_error (GRUB_ERR_BAD_SIGNATURE, N_("bad signature"));
+     }
++
++  /* Bit 6 unset: old format packet length */
+   *out_type = ((type >> 2) & 0xf);
+   switch (type & 0x3)
+     {

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -229,3 +229,4 @@ use-time-register-in-grub_efi_get_time_ms.patch
 deepin/0006-grub-install-support-secureboot-detect-for-loongarch.patch
 uniontech-mkconfig_lib-suppress-stderr-for-grub-probe-in-uses_abstraction.patch
 uniontech-update-zh-cn-translate.patch
+commands-pgp-5ee2e04d.patch


### PR DESCRIPTION
Backport critical fix from upstream gnu-grub/grub.

## Patch

- **commands-pgp**:  fix new-format packet length parsing.
  Upstream: [gnu-grub/grub@6fee32fd](https://gitlab.freedesktop.org/gnu-grub/grub/-/commit/5ee2e04db4ec48c049518f9bb5a126e66bd3d391)

## Test Plan

- quilt push -a succeeds cleanly (Debian only)
- dpkg-buildpackage builds successfully (Debian only)