### PR TITLE
fix(grub2): CVE-2024-56738

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+grub2 (2.12-7deepin15) unstable; urgency=medium
+
+  * fix(cve): CVE-2024-56738
+
+ -- deepin-ci-robot <packages@deepin.org>  Tue, 16 Jun 2026 20:28:33 +0800
+
 grub2 (2.12-7deepin14) unstable; urgency=medium
 
   * fix(sw64): fix EFI call compatibility and PE machine detection

--- a/debian/patches/fix-CVE-2024-56738.patch
+++ b/debian/patches/fix-CVE-2024-56738.patch
@@ -1,0 +1,41 @@
+From 8b1b47efd667ea3450681fa0c674045980e25360 Mon Sep 17 00:00:00 2001
+From: Jonathan Bar Or <jonathanbaror@gmail.com>
+Date: Mon, 7 Apr 2025 09:36:34 +0000
+Subject: [PATCH] fix CVE-2024-56738
+
+Reference:https://savannah.gnu.org/bugs/?66603
+Conflict:NA
+
+---
+ grub-core/lib/crypto.c | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/grub-core/lib/crypto.c b/grub-core/lib/crypto.c
+index d53ddbe..653aab7 100644
+--- a/grub-core/lib/crypto.c
++++ b/grub-core/lib/crypto.c
+@@ -440,16 +440,16 @@ grub_crypto_gcry_error (gcry_err_code_t in)
+ int
+ grub_crypto_memcmp (const void *a, const void *b, grub_size_t n)
+ {
+-  register grub_size_t counter = 0;
+-  const grub_uint8_t *pa, *pb;
++  register grub_uint8_t indicator = 0;
++  const grub_uint8_t *pa = a, *pb = b;
++  grub_size_t i;
+ 
+-  for (pa = a, pb = b; n; pa++, pb++, n--)
++  for (i = 0; i < n; i++)
+     {
+-      if (*pa != *pb)
+-	counter++;
++	indicator |= (pa[i] ^ pb[i]);
+     }
+ 
+-  return !!counter;
++  return !!indicator;
+ }
+ 
+ #ifndef GRUB_UTIL
+-- 
+2.33.0

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -229,3 +229,4 @@ use-time-register-in-grub_efi_get_time_ms.patch
 deepin/0006-grub-install-support-secureboot-detect-for-loongarch.patch
 uniontech-mkconfig_lib-suppress-stderr-for-grub-probe-in-uses_abstraction.patch
 uniontech-update-zh-cn-translate.patch
+fix-CVE-2024-56738.patch


### PR DESCRIPTION
fix: CVE-2024-56738

Fix CVE-2024-56738 for grub2.

Log: Fix CVE-2024-56738

## Summary by Sourcery

Bug Fixes:
- Patch grub2 to fix vulnerability CVE-2024-56738 via a new Debian patch entry and changelog update.